### PR TITLE
Kleine fixes in nieuwe hookable functionaliteit

### DIFF
--- a/src/edwh/improved_invoke.py
+++ b/src/edwh/improved_invoke.py
@@ -11,6 +11,7 @@ import typing
 import warnings
 from typing import Any, Callable, Iterable, Optional
 
+from fabric import Connection
 from invoke.context import Context
 from invoke.tasks import Task as InvokeTask
 from invoke.tasks import task as invoke_task
@@ -166,7 +167,7 @@ class ImprovedTask(InvokeTask[TaskCallable]):
                 elif subresult is not None:
                     ctx["result"] = subresult
 
-    def __call__(self, ctx: Context, *args, **kwargs):
+    def __call__(self, ctx: Context | Connection, *args, **kwargs):
         """Invoke the callable instance.
 
         Args:
@@ -177,7 +178,9 @@ class ImprovedTask(InvokeTask[TaskCallable]):
         Returns:
             The result of the superclass call.
         """
-        ctx["result"] = ctx.get("result") or {}
+        # ctx.get works for Context but not for Connection!
+        setattr(ctx, "result", getattr(ctx, "result", {}))  # ctx["result"] = ctx.get("result") or {}
+
         result = super().__call__(ctx, *args, **kwargs)
 
         if isinstance(ctx["result"], dict) and isinstance(result, dict):

--- a/src/edwh/improved_invoke.py
+++ b/src/edwh/improved_invoke.py
@@ -39,7 +39,7 @@ class TaskOptions(typing.TypedDict, total=False):
     iterable: Optional[Iterable[str]]
     incrementable: Optional[Iterable[str]]
     flags: dict[str, Iterable[str]] | None
-    hookable: bool
+    hookable: Optional[bool]
 
 
 class TaskCallable(typing.Protocol):
@@ -76,7 +76,7 @@ class ImprovedTask(InvokeTask[TaskCallable]):
         incrementable: Optional[Iterable[str]] = None,
         # new:
         flags: dict[str, Iterable[str]] | None = None,
-        hookable: bool = False,
+        hookable: Optional[bool] = None,
     ):
         self._flags = flags or {}
         self.hookable = hookable
@@ -153,7 +153,7 @@ class ImprovedTask(InvokeTask[TaskCallable]):
             **kwargs: Keyword arguments for the hooks.
         """
         for namespace, task in find_task_across_namespaces(self.name).items():
-            if task is not self:
+            if task is not self and task.hookable is not False:
                 try:
                     subresult = self._execute_subtask(ctx, task, *args, **kwargs)
                 except Exception as e:
@@ -200,6 +200,68 @@ def find_task_across_namespaces(name: str) -> dict[str, ImprovedTask]:
     return {ns.name: task for ns in collection.collections.values() if (task := ns.tasks.get(name))}
 
 
-improved_task: TaskCallable = functools.partial(invoke_task, klass=ImprovedTask)
+def improved_task(*fn: Optional[TaskCallable], **options: Unpack[TaskOptions]) -> TaskCallable:
+    """
+    Marks wrapped callable object as a valid Invoke task.
+
+    This function may be called without any parentheses if no extra options need to be
+    specified. Otherwise, the following keyword arguments are allowed in the
+    parenthesized form:
+
+    Args:
+        name (str): Default name to use when binding to a `.Collection`. Useful for
+            avoiding Python namespace issues (i.e. when the desired CLI level name
+            can't or shouldn't be used as the Python level name.)
+        aliases (List[str]): Specify one or more aliases for this task, allowing it to be
+            invoked as multiple different names. For example, a task named ``mytask``
+            with a simple ``@task`` wrapper may only be invoked as ``"mytask"``.
+            Changing the decorator to be ``@task(aliases=['myothertask'])`` allows
+            invocation as ``"mytask"`` *or* ``"myothertask"``.
+        positional (Iterable[str]): Iterable overriding the parser's automatic "args with no
+            default value are considered positional" behavior. If a list of arg
+            names, no args besides those named in this iterable will be considered
+            positional. (This means that an empty list will force all arguments to be
+            given as explicit flags.)
+        optional (Iterable[str]): Iterable of argument names, declaring those args to
+            have optional values. Such arguments may be
+            given as value-taking options (e.g. ``--my-arg=myvalue``, wherein the
+            task is given ``"myvalue"``) or as Boolean flags (``--my-arg``, resulting
+            in ``True``).
+        iterable (Iterable[str]): Iterable of argument names, declaring them to build
+            iterable values.
+        incrementable (Iterable[str]): Iterable of argument names, declaring them to
+            increment their values.
+        default (bool): Boolean option specifying whether this task should be its
+            collection's default task (i.e. called if the collection's own name is
+            given.)
+        auto_shortflags (bool): Whether or not to automatically create short
+            flags from task options; defaults to True.
+        help (Dict[str, str]): Dict mapping argument names to their help strings. Will be
+            displayed in ``--help`` output. For arguments containing underscores
+            (which are transformed into dashes on the CLI by default), either the
+            dashed or underscored version may be supplied here.
+        pre (List[TaskCallable]): Lists of task objects to execute prior to the wrapped
+            task whenever it is executed.
+        post (List[TaskCallable]): Lists of task objects to execute after the wrapped
+            task whenever it is executed.
+        autoprint (bool): Boolean determining whether to automatically print this
+            task's return value to standard output when invoked directly via the CLI.
+            Defaults to False.
+        flags (dict[str, list[str]]): Mapping of flag names that modify task behavior.
+                               e.g. `@task(flags={'exclude': ['--exclude', '-x'], 'as_json': ['--json']})`
+        hookable (Optional[bool]): Boolean option that controls whether the task can be hooked by plugins.
+                                       - **True**: This setting is primarily used by core tasks. It allows the task to look for other tasks (from plugins or local definitions) with the same name and execute them after the main task completes. This enables a cascading execution of tasks, enhancing modularity and reusability.
+                                       - **False**: This setting is typically used by local or plugin tasks to indicate that they do not want to be hooked by core tasks, even if they share the same name. This ensures that the task remains isolated and does not trigger any unintended behavior from cascading executions.
+                                       - **None** (default): This represents the default behavior. For core tasks, it means that the task will not search for other tasks with the same name to execute. For local or plugin tasks, it allows them to be hooked by other tasks.
+        fn (TaskCallable): when you use `@task` without parentheses, this is the function you're decorating.
+                            Using `@task()` with parens is recommended for better type-hints.
+
+    If any non-keyword arguments are given, they are taken as the value of the
+    ``pre`` kwarg for convenience's sake. (It is an error to give both
+    ``*args`` and ``pre`` at the same time.)
+    """
+    options["klass"] = ImprovedTask
+    return invoke_task(*fn, **options)
+
 
 __all__ = ["ImprovedTask", "improved_task"]

--- a/src/edwh/improved_invoke.py
+++ b/src/edwh/improved_invoke.py
@@ -5,7 +5,6 @@
 >>> def something(): ...
 """
 
-import functools
 import inspect
 import typing
 import warnings
@@ -260,8 +259,7 @@ def improved_task(*fn: Optional[TaskCallable], **options: Unpack[TaskOptions]) -
     ``pre`` kwarg for convenience's sake. (It is an error to give both
     ``*args`` and ``pre`` at the same time.)
     """
-    options["klass"] = ImprovedTask
-    return invoke_task(*fn, **options)
+    return invoke_task(*fn, **options, klass=ImprovedTask)
 
 
 __all__ = ["ImprovedTask", "improved_task"]

--- a/src/edwh/tasks.py
+++ b/src/edwh/tasks.py
@@ -964,7 +964,7 @@ def setup(c: Context, new_config_toml: bool = False, _retry: bool = False) -> di
         cprint("docker-compose file is missing, setup might not be completed properly!", color="yellow")
 
     # local/plugin setup happens here because of `hookable`
-    return {"success": True, "services": ["todo"]}
+    return {}
 
 
 @task()
@@ -1186,7 +1186,7 @@ def up(
     }
 
 
-@task
+@task()
 def inspect_health(ctx, container: str, quiet: bool = False) -> dict:
     tab = " " * 2
     result = {}


### PR DESCRIPTION
## Samenvatting door Sourcery

Deze PR introduceert kleine correcties en verbeteringen aan de hookable task functionaliteit. Het werkt ook de task decorator bij om hookable tasks toe te staan.

Verbeteringen:
- Werkt de task decorator bij om hookable tasks toe te staan.
- Verbetert de afhandeling van context in tasks om te werken met zowel Context- als Connection-objecten.
- Werkt de setup task bij om een lege dictionary terug te geven in plaats van een dictionary met een success key en een lijst met services.
- Voegt de haakjes toe aan de task decorator in de inspect_health task.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

This PR introduces minor fixes and improvements to the hookable task functionality. It also updates the task decorator to allow hookable tasks.

Enhancements:
- Updates the task decorator to allow hookable tasks.
- Improves the handling of context in tasks to work with both Context and Connection objects.
- Updates the setup task to return an empty dictionary instead of a dictionary with a success key and a list of services.
- Adds the parenthesis to the task decorator in the inspect_health task.

</details>