### PR TITLE
feat: unlock keyring on headless machine via SSH-agent backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 - [Installation](#installation)
 - [Usage](#usage)
+- [Sudo authentication](#sudo-authentication)
 - [Linting](#linting)
 - [Plugins](#plugins)
 - [License](#license)
@@ -41,6 +42,23 @@ ew help <namespace> # e.g. `ew help plugin`
 # to see help about a specific command:
 ew help <command> # e.g. `ew help plugin.list` 
 ```
+
+## Sudo authentication
+
+`edwh sudo` verifies your sudo password and safely stores it temporarily so commands that require sudo can run without
+prompting again.
+
+By default, EDWH uses the operating system keyring (for example, GNOME Secret Service on Linux). This is the preferred
+backend when the desktop session and its keyring are available.
+
+When the system keyring is locked, `edwh sudo` offers an SSH-agent fallback. If you accept, EDWH lists the public keys
+available through `ssh-add -L`; select the key whose agent should unlock the encrypted EDWH keyring. The selection is
+recorded in `~/.config/ssh-agent-keyring/config.json`, the SSH-agent backend's documented configuration file, and later
+EDWH commands automatically use that backend.
+
+The SSH-agent backend requires a reachable agent, `SSH_AUTH_SOCK`, and the selected key loaded in that agent. For a
+remote development machine, connect with agent forwarding (`ssh -A` or `ForwardAgent yes`). The sudo password remains
+encrypted on disk; access depends on the selected SSH agent rather than a second keyring password.
 
 ## Linting
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     "rapidfuzz < 4",  # levenshtein my beloved
     "requests < 3", # better than urllib no?
     "ruff==0.15.21", # For `edwh fmt`, `edwh lint`
+    "ssh-agent-keyring >= 0.2, < 1", # encrypted keyring for SSH-only sessions
     "tabulate >= 0.9, < 0.10", # for nice cli tables; b2 4.x is incompatible with 0.10+
     "termcolor < 3", # improved ansi colored print (v3 removes Color type)
     "ty==0.0.60", # For `edwh lint`

--- a/src/edwh/tasks.py
+++ b/src/edwh/tasks.py
@@ -9,6 +9,7 @@ import pathlib
 import re
 import shlex
 import shutil
+import subprocess
 import sys
 import threading
 import time
@@ -923,6 +924,28 @@ def prompt_validate_sudo_pass(c: Context):
         return None
 
 
+def ensure_keyring_unlocked() -> bool:
+    """Offer to unlock a locked GNOME keyring before using it."""
+    try:
+        keyring.get_password("edwh", "sudo")
+    except keyring.errors.KeyringLocked:
+        if not confirm("The system keyring is locked. Would you like to unlock it? [Yn]", default=True):
+            return False
+
+        keyring_password = getpass("Please enter the keyring password: ")
+        result = subprocess.run(
+            ["gnome-keyring-daemon", "--unlock", "--components=secrets"],
+            input=keyring_password,
+            text=True,
+            check=False,
+        )
+        if result.returncode:
+            cprint("Unable to unlock the system keyring.", color="red")
+            return False
+
+    return True
+
+
 @task()
 def require_sudo(c: Context) -> bool:
     """
@@ -969,6 +992,9 @@ def build_toml(c: Context, overwrite: bool = False) -> TomlConfig | None:
 
 @task()
 def sudo(c: Context):
+    if not ensure_keyring_unlocked():
+        return
+
     # 1.
     # check current status in keyring
     try:

--- a/src/edwh/tasks.py
+++ b/src/edwh/tasks.py
@@ -35,6 +35,7 @@ from ewok import Context, Task, format_frame, task
 from invoke import Promise, Runner
 from packaging.version import parse as parse_version
 from rapidfuzz import fuzz
+from ssh_agent_keyring.backend import SSHAgentKeyring
 from termcolor import colored, cprint
 from termcolor._types import Color
 from typing_extensions import Never
@@ -924,24 +925,55 @@ def prompt_validate_sudo_pass(c: Context):
         return None
 
 
+def ssh_agent_keyring_config_path() -> Path:
+    config_root = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config"))
+    return config_root / "ssh-agent-keyring" / "config.json"
+
+
+def use_configured_ssh_agent_keyring() -> bool:
+    if not ssh_agent_keyring_config_path().exists():
+        return False
+
+    keyring.set_keyring(SSHAgentKeyring())
+    return True
+
+
+def configure_ssh_agent_keyring() -> bool:
+    result = subprocess.run(["ssh-add", "-L"], text=True, capture_output=True, check=False)
+    public_keys = [key for key in result.stdout.splitlines() if key.startswith("ssh-")]
+    if not public_keys:
+        cprint("No public keys are available from SSH_AUTH_SOCK.", color="red")
+        return False
+
+    options = {
+        public_key: f"{parts[0]} {parts[1][:20]}… {' '.join(parts[2:])}".strip()
+        for public_key in public_keys
+        if len(parts := public_key.split()) >= 2
+    }
+    public_key = interactive_selected_radio_value(options, prompt="Select the SSH key for EDWH's encrypted keyring:")
+    if not public_key:
+        return False
+
+    config_path = ssh_agent_keyring_config_path()
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config = json.loads(config_path.read_text()) if config_path.exists() else {}
+    config["public_key"] = public_key
+    config_path.write_text(json.dumps(config, indent=2) + "\n")
+
+    keyring.set_keyring(SSHAgentKeyring())
+    return True
+
+
 def ensure_keyring_unlocked() -> bool:
-    """Offer to unlock a locked GNOME keyring before using it."""
+    """Offer a secure SSH-agent fallback when the system keyring is locked."""
+    use_configured_ssh_agent_keyring()
+
     try:
         keyring.get_password("edwh", "sudo")
     except keyring.errors.KeyringLocked:
-        if not confirm("The system keyring is locked. Would you like to unlock it? [Yn]", default=True):
-            return False
-
-        keyring_password = getpass("Please enter the keyring password: ")
-        result = subprocess.run(
-            ["gnome-keyring-daemon", "--unlock", "--components=secrets"],
-            input=keyring_password,
-            text=True,
-            check=False,
-        )
-        if result.returncode:
-            cprint("Unable to unlock the system keyring.", color="red")
-            return False
+        if confirm("The system keyring is locked. Would you like to use your SSH agent instead? [Yn]", default=True):
+            return configure_ssh_agent_keyring()
+        return False
 
     return True
 
@@ -962,6 +994,8 @@ def require_sudo(c: Context) -> bool:
                 c.sudo('echo "I am the captain now."')
 
     """
+    use_configured_ssh_agent_keyring()
+
     ran = c.run("sudo --non-interactive echo ''", warn=True, hide=True)
     if ran and ran.ok:
         # prima


### PR DESCRIPTION
Useful for `edwh sudo` on dev machine via tailscale :) 