### PR TITLE
feat(plugin.release): route releases to vommit, offering migration from psr

### DIFF
--- a/coding-guidelines.md
+++ b/coding-guidelines.md
@@ -385,37 +385,19 @@ edwh plugin.release --patch  # 1.1.0 -> 1.1.1
 edwh plugin.release --major  # 1.1.1 -> 2.0.0
 ```
 
-`plugin.release` picks the release tool from the project it runs in:
+`plugin.release` picks its tool from the project: `[tool.vommit]` means
+[vommit](https://github.com/educationwarehouse/vommit), `[tool.semantic_release]`
+means psr (deprecated, removed in edwh 2.0), neither means you are offered
+`vommit setup`. A psr project is offered the switch: migrate now, not now, or
+never (recorded as `[tool.edwh.release] backend = "psr"`). `EDWH_NON_INTERACTIVE=1`
+skips the prompt and keeps the current tool.
 
-- **`[tool.vommit]` present** — [vommit](https://github.com/educationwarehouse/vommit)
-  releases it. `--hatch` does not apply; set `[tool.vommit.commands]` `build` and
-  `publish` instead.
-- **`[tool.semantic_release]` present** — python-semantic-release still works, but it
-  is deprecated and will be removed in edwh 2.0. You are offered a switch:
-
-  | Answer | What happens |
-  |---|---|
-  | migrate now | Installs vommit if needed, copies your PyPI token into vommit's keyring (edwh's stays), then runs vommit's interactive migrator |
-  | not now | Releases with psr this time, asks again next release |
-  | never | Records `[tool.edwh.release] backend = "psr"` and stops asking |
-
-- **Neither** — you are offered `vommit setup` to configure the project.
-
-Migration note: v7 projects here set `upload_to_repository = false` because
-`plugin.release` did the uploading. vommit translates that faithfully to
-`pypi.enabled = false`, so after migrating you are asked whether to turn
-publishing back on. Say yes unless something else uploads for you.
-
-`EDWH_NON_INTERACTIVE=1` suppresses all of these prompts: the project keeps its
-current backend and a deprecation notice is printed instead.
-
-Once vommit is installed its own tasks are available too, for anything
-`plugin.release` does not expose (`--version`, `--allow-dirty`, `--no-bump`):
-
-```bash
-edwh vommit.release --version 2.0.0
-edwh vommit.migrate --on-unsupported=error
-```
+Migrating copies your PyPI token into vommit's keyring and asks whether to
+re-enable publishing — our v7 configs set `upload_to_repository = false` because
+`plugin.release` uploaded instead, and vommit would otherwise stop publishing.
+On vommit, `--hatch` is replaced by `[tool.vommit.commands]` build/publish, and
+`edwh vommit.*` exposes what `plugin.release` doesn't (`--version`,
+`--allow-dirty`, `--no-bump`).
 
 ## Anti-Patterns to Avoid
 

--- a/coding-guidelines.md
+++ b/coding-guidelines.md
@@ -392,12 +392,12 @@ means psr (deprecated, removed in edwh 2.0), neither means you are offered
 never (recorded as `[tool.edwh.release] backend = "psr"`). `EDWH_NON_INTERACTIVE=1`
 skips the prompt and keeps the current tool.
 
-Migrating copies your PyPI token into vommit's keyring and asks whether to
-re-enable publishing — our v7 configs set `upload_to_repository = false` because
-`plugin.release` uploaded instead, and vommit would otherwise stop publishing.
-On vommit, `--hatch` is replaced by `[tool.vommit.commands]` build/publish, and
-`edwh vommit.*` exposes what `plugin.release` doesn't (`--version`,
-`--allow-dirty`, `--no-bump`).
+Migrating copies your PyPI token into vommit's keyring. Our v7 configs set
+`upload_to_repository = false` because `plugin.release` did the uploading;
+vommit reports that and keeps publishing on, so check `pypi.enabled` if the
+project should publish nothing. On vommit, `--hatch` is replaced by
+`[tool.vommit.commands]` build/publish, and `edwh vommit.*` exposes what
+`plugin.release` doesn't (`--version`, `--allow-dirty`, `--no-bump`).
 
 ## Anti-Patterns to Avoid
 

--- a/coding-guidelines.md
+++ b/coding-guidelines.md
@@ -385,6 +385,38 @@ edwh plugin.release --patch  # 1.1.0 -> 1.1.1
 edwh plugin.release --major  # 1.1.1 -> 2.0.0
 ```
 
+`plugin.release` picks the release tool from the project it runs in:
+
+- **`[tool.vommit]` present** — [vommit](https://github.com/educationwarehouse/vommit)
+  releases it. `--hatch` does not apply; set `[tool.vommit.commands]` `build` and
+  `publish` instead.
+- **`[tool.semantic_release]` present** — python-semantic-release still works, but it
+  is deprecated and will be removed in edwh 2.0. You are offered a switch:
+
+  | Answer | What happens |
+  |---|---|
+  | migrate now | Installs vommit if needed, copies your PyPI token into vommit's keyring (edwh's stays), then runs vommit's interactive migrator |
+  | not now | Releases with psr this time, asks again next release |
+  | never | Records `[tool.edwh.release] backend = "psr"` and stops asking |
+
+- **Neither** — you are offered `vommit setup` to configure the project.
+
+Migration note: v7 projects here set `upload_to_repository = false` because
+`plugin.release` did the uploading. vommit translates that faithfully to
+`pypi.enabled = false`, so after migrating you are asked whether to turn
+publishing back on. Say yes unless something else uploads for you.
+
+`EDWH_NON_INTERACTIVE=1` suppresses all of these prompts: the project keeps its
+current backend and a deprecation notice is printed instead.
+
+Once vommit is installed its own tasks are available too, for anything
+`plugin.release` does not expose (`--version`, `--allow-dirty`, `--no-bump`):
+
+```bash
+edwh vommit.release --version 2.0.0
+edwh vommit.migrate --on-unsupported=error
+```
+
 ## Anti-Patterns to Avoid
 
 ### Code Smells

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -249,6 +249,11 @@ profile = "black"
 # Tests can use magic values, assertions, and relative imports
 "tests/**/*" = ["PLR2004", "S101", "TID252"]
 
+[tool.pytest.ini_options]
+pythonpath = [
+    "src",
+]
+
 [tool.coverage.run]
 source_pkgs = ["edwh", "tests"]
 branch = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,15 @@ dev = [
     "types-requests",
     "types-python-dateutil",
     "types-redis",
-    "types-tabulate"
+    "types-tabulate",
+    "vommit >= 0.1.1, < 1", # so `edwh lint` can resolve the optional release backend
+]
+
+# The modern release backend. Optional at runtime: `plugin.release` offers to
+# install it when a project wants it. Deliberately NOT in `plugins` below --
+# that list is read by `plugin.list`, which expects edwh-*-plugin names.
+vommit = [
+    "vommit >= 0.1.1, < 1",
 ]
 
 omgeving = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,15 +67,10 @@ dev = [
     "types-python-dateutil",
     "types-redis",
     "types-tabulate",
-    "vommit >= 0.1.1, < 1", # so `edwh lint` can resolve the optional release backend
+    "vommit >= 0.1.1, < 1", # so `edwh lint` can resolve it
 ]
 
-# The modern release backend. Optional at runtime: `plugin.release` offers to
-# install it when a project wants it. Deliberately NOT in `plugins` below --
-# that list is read by `plugin.list`, which expects edwh-*-plugin names.
-vommit = [
-    "vommit >= 0.1.1, < 1",
-]
+vommit = ["vommit >= 0.1.1, < 1"] # release backend; keep out of `plugins`
 
 omgeving = [
     # no extra dependencies anymore !

--- a/src/edwh/local_tasks/plugin.py
+++ b/src/edwh/local_tasks/plugin.py
@@ -43,11 +43,8 @@ from ..release_backend import (
     Backend,
     copy_pypi_token,
     detect_backend,
-    enable_publishing,
     pin_backend,
-    psr_uploaded,
     store_vommit_pypi_token,
-    vommit_publishes,
 )
 
 
@@ -896,12 +893,9 @@ def _offer_switch(c: Context, backend: Backend, pyproject: Path) -> Backend:
 
 def _migrate_to_vommit(c: Context, pyproject: Path) -> Backend:
     """
-    Copy the PyPI token across, run vommit's migrator, then repair publishing.
+    Copy the PyPI token across, then hand over to vommit's migrator.
     """
     copy_pypi_token()
-
-    # psr's upload flags have to be read before the migrator strips its table
-    uploaded = psr_uploaded(pyproject)
 
     vommit_tasks = _vommit()
     assert vommit_tasks, "ensure_vommit returned True without vommit being importable"
@@ -911,7 +905,6 @@ def _migrate_to_vommit(c: Context, pyproject: Path) -> Backend:
         cprint("Migration did not complete; releasing with python-semantic-release for now.", "yellow")
         return "psr"
 
-    _restore_publishing(pyproject, psr_uploaded=uploaded)
     return "vommit"
 
 
@@ -939,29 +932,6 @@ def _vommit_configured(pyproject: Path) -> bool:
     from vommit.config import Config
 
     return Config.has_pyproject_config(pyproject)
-
-
-def _restore_publishing(pyproject: Path, psr_uploaded: bool) -> None:
-    """
-    Put back the publishing step a faithful migration just removed.
-
-    psr was not uploading because `plugin.release` did it afterwards, so
-    `upload_to_repository = false` translates to `pypi.enabled = false` and the
-    project silently stops reaching PyPI. vommit cannot know that; we can.
-    """
-    if psr_uploaded or vommit_publishes(pyproject):
-        return
-
-    cprint(
-        "python-semantic-release was not uploading, so vommit turned publishing off. "
-        "But `plugin.release` was doing that upload, and vommit owns that step now.",
-        "yellow",
-    )
-    if confirm("Enable publishing (pypi.enabled = true)? [Yn] ", default=True):
-        enable_publishing(pyproject)
-        cprint("Enabled vommit's publishing step.", "green")
-    else:
-        cprint("Left publishing off: `vommit release` will bump, tag and push, but not publish.", "yellow")
 
 
 def _resolve_backend(c: Context, pyproject: Path = PYPROJECT) -> Optional[Backend]:

--- a/src/edwh/local_tasks/plugin.py
+++ b/src/edwh/local_tasks/plugin.py
@@ -734,6 +734,42 @@ def _vommit() -> Optional[VommitTasks]:
     return typing.cast(VommitTasks, vommit_tasks)
 
 
+# Used only when edwh's own metadata cannot be read, which happens when it runs
+# from a source tree that was never installed.
+VOMMIT_FALLBACK_SPECIFIER = ">=0.1.1,<1"
+
+
+def _vommit_specifier() -> str:
+    """
+    The version range the `vommit` extra declares.
+
+    Read from edwh's metadata rather than written down twice, so widening the
+    extra cannot leave the install prompt behind on the old range.
+    """
+    from importlib.metadata import PackageNotFoundError, requires
+
+    from packaging.requirements import InvalidRequirement, Requirement
+
+    try:
+        declared = requires("edwh") or ()
+    except PackageNotFoundError:
+        return VOMMIT_FALLBACK_SPECIFIER
+
+    for requirement in declared:
+        try:
+            parsed = Requirement(requirement)
+        except InvalidRequirement:
+            continue
+
+        if parsed.name != "vommit" or not parsed.marker:
+            continue
+
+        if parsed.marker.evaluate({"extra": "vommit"}):
+            return str(parsed.specifier)
+
+    return VOMMIT_FALLBACK_SPECIFIER
+
+
 def _vommit_spec() -> str:
     """
     What to install, taking edwh's keyring backend into account.
@@ -744,17 +780,22 @@ def _vommit_spec() -> str:
     """
     from ..tasks import ssh_agent_keyring_config_path
 
-    return "vommit[ssh]" if ssh_agent_keyring_config_path().exists() else "vommit"
+    extras = "[ssh]" if ssh_agent_keyring_config_path().exists() else ""
+
+    return f"vommit{extras}{_vommit_specifier()}"
 
 
-@task()
-def require_vommit(ctx: Context) -> bool:
+def ensure_vommit(ctx: Context) -> bool:
     """
     Ensure vommit is importable, offering to install it when it isn't.
 
     Installs into edwh's own environment rather than via uvenv: that is what
     activates vommit's `edwh` entry point, so `edwh vommit.*` starts working
     too.
+
+    A plain function rather than a task, because ewok writes a task's return
+    value into the shared `ctx["result"]`, and the enclosing task then returns
+    that instead of its own -- which would make `plugin.bump` answer False.
     """
     if _vommit():
         return True
@@ -773,6 +814,14 @@ def require_vommit(ctx: Context) -> bool:
 
     cprint("vommit was installed but is not importable yet; please run this command again.", "yellow")
     return False
+
+
+@task()
+def require_vommit(ctx: Context) -> None:
+    """
+    Install vommit, the release backend, if this environment lacks it.
+    """
+    ensure_vommit(ctx)
 
 
 SWITCH_NOW = "now"
@@ -836,7 +885,7 @@ def _offer_switch(c: Context, backend: Backend, pyproject: Path) -> Backend:
     elif answer != SWITCH_NOW:
         # "not now", or the prompt was abandoned
         return backend
-    elif not require_vommit(c):
+    elif not ensure_vommit(c):
         return backend
 
     if migrating:
@@ -855,7 +904,7 @@ def _migrate_to_vommit(c: Context, pyproject: Path) -> Backend:
     uploaded = psr_uploaded(pyproject)
 
     vommit_tasks = _vommit()
-    assert vommit_tasks, "require_vommit returned True without vommit being importable"
+    assert vommit_tasks, "ensure_vommit returned True without vommit being importable"
     vommit_tasks.migrate(c, project_dir=str(pyproject.parent))
 
     if not _vommit_configured(pyproject):
@@ -871,7 +920,7 @@ def _setup_vommit(c: Context, pyproject: Path) -> Backend:
     Run vommit's interactive setup on a project with no release config.
     """
     vommit_tasks = _vommit()
-    assert vommit_tasks, "require_vommit returned True without vommit being importable"
+    assert vommit_tasks, "ensure_vommit returned True without vommit being importable"
     vommit_tasks.setup(c, project_dir=str(pyproject.parent))
 
     if not _vommit_configured(pyproject):
@@ -915,16 +964,24 @@ def _restore_publishing(pyproject: Path, psr_uploaded: bool) -> None:
         cprint("Left publishing off: `vommit release` will bump, tag and push, but not publish.", "yellow")
 
 
-def _resolve_backend(c: Context, pyproject: Path = PYPROJECT) -> Backend:
+def _resolve_backend(c: Context, pyproject: Path = PYPROJECT) -> Optional[Backend]:
     """
     Which backend releases this project, asking about a switch when relevant.
 
     The single funnel for `release` and `bump`, so the deprecation notice lands
-    here once rather than at every place that could reach the psr path.
+    here once rather than at every place that could reach the psr path. None
+    means this project cannot be released and the reason has been reported.
     """
     backend = detect_backend(pyproject)
+
     if backend == "vommit":
-        return backend
+        # vommit is an optional extra, so its config outlives its install: a
+        # migrated project on a second machine has the one without the other.
+        if _vommit():
+            return backend
+
+        cprint(f"{pyproject} is configured for vommit, but vommit is not installed.", "yellow")
+        return backend if ensure_vommit(c) else None
 
     backend = _offer_switch(c, backend, pyproject)
 
@@ -1094,7 +1151,12 @@ def bump(
     """
     Bump this project's version, using whichever release tool it is configured for.
     """
-    if _resolve_backend(c) == "vommit":
+    backend = _resolve_backend(c)
+
+    if backend is None:
+        return None
+
+    if backend == "vommit":
         vommit_tasks = _vommit()
         assert vommit_tasks, "backend resolved to vommit without vommit being importable"
         return vommit_tasks.bump(
@@ -1105,6 +1167,12 @@ def bump(
             prerelease=prerelease,
             noop=noop,
         )
+
+    if backend == "none":
+        # falling through here would install psr and run it against a project
+        # that has no psr config to run against
+        cprint("No release configuration; nothing to bump.", "yellow")
+        return None
 
     return _psr_bump(
         c,
@@ -1155,6 +1223,9 @@ def release(
     # check, so resolving the backend before pulling would change what --pull
     # means for a project that migrates during this very run.
     backend = _resolve_backend(c)
+
+    if backend is None:
+        return
 
     if backend == "vommit":
         if hatch:

--- a/src/edwh/local_tasks/plugin.py
+++ b/src/edwh/local_tasks/plugin.py
@@ -45,6 +45,10 @@ from ..release_backend import (
     detect_backend,
     pin_backend,
     store_vommit_pypi_token,
+    vommit_configured,
+    vommit_specifier,
+    vommit_tasks,
+    vommit_token_complaint,
 )
 
 
@@ -675,98 +679,6 @@ PSR_DEPRECATION = (
 )
 
 
-class VommitTasks(typing.Protocol):
-    """
-    The four vommit tasks we call, and the arguments we call them with.
-
-    Spelled out rather than typed as a module, so a mistake in a keyword or a
-    reshape on vommit's side is a type error here instead of an AttributeError
-    during someone's release. `tests/test_release_backend.py` checks the real
-    signatures still match.
-    """
-
-    def setup(self, c: Context, /, *, project_dir: str) -> None: ...
-
-    def migrate(self, c: Context, /, *, project_dir: str) -> None: ...
-
-    def bump(
-        self,
-        c: Context,
-        /,
-        *,
-        major: bool = False,
-        minor: bool = False,
-        patch: bool = False,
-        prerelease: bool = False,
-        noop: bool = False,
-    ) -> Optional[str]: ...
-
-    def release(
-        self,
-        c: Context,
-        /,
-        *,
-        major: bool = False,
-        minor: bool = False,
-        patch: bool = False,
-        prerelease: bool = False,
-        noop: bool = False,
-        yes: bool = False,
-    ) -> Optional[str]: ...
-
-
-def _vommit() -> Optional[VommitTasks]:
-    """
-    vommit's tasks, or None when the `edwh[vommit]` extra isn't installed.
-
-    They take a Context and are callable in-process, which is why vommit is a
-    dependency rather than a tool we shell out to: `bump` hands back the new
-    version instead of us regex-scraping it out of another process' stderr.
-    """
-    try:
-        from vommit import tasks as vommit_tasks
-    except ImportError:
-        return None
-
-    return typing.cast(VommitTasks, vommit_tasks)
-
-
-# Used only when edwh's own metadata cannot be read, which happens when it runs
-# from a source tree that was never installed.
-VOMMIT_FALLBACK_SPECIFIER = ">=0.1.1,<1"
-
-
-def _vommit_specifier() -> str:
-    """
-    The version range the `vommit` extra declares.
-
-    Read from edwh's metadata rather than written down twice, so widening the
-    extra cannot leave the install prompt behind on the old range.
-    """
-    from importlib.metadata import PackageNotFoundError, requires
-
-    from packaging.requirements import InvalidRequirement, Requirement
-
-    try:
-        declared = requires("edwh") or ()
-    except PackageNotFoundError:
-        return VOMMIT_FALLBACK_SPECIFIER
-
-    for requirement in declared:
-        try:
-            parsed = Requirement(requirement)
-        except InvalidRequirement:
-            continue
-
-        if parsed.name != "vommit" or not parsed.marker:
-            continue
-
-        if parsed.marker.evaluate({"extra": "vommit"}):
-            return str(parsed.specifier)
-
-    return VOMMIT_FALLBACK_SPECIFIER
-
-
 def _vommit_spec() -> str:
     """
     What to install, taking edwh's keyring backend into account.
@@ -775,11 +687,12 @@ def _vommit_spec() -> str:
     project relying on it would install vommit and still be unable to reach its
     own PyPI token.
     """
+    # local: ..tasks imports this module's package, so a top-level import cycles
     from ..tasks import ssh_agent_keyring_config_path
 
     extras = "[ssh]" if ssh_agent_keyring_config_path().exists() else ""
 
-    return f"vommit{extras}{_vommit_specifier()}"
+    return f"vommit{extras}{vommit_specifier()}"
 
 
 def ensure_vommit(ctx: Context) -> bool:
@@ -794,7 +707,7 @@ def ensure_vommit(ctx: Context) -> bool:
     value into the shared `ctx["result"]`, and the enclosing task then returns
     that instead of its own -- which would make `plugin.bump` answer False.
     """
-    if _vommit():
+    if vommit_tasks():
         return True
 
     spec = _vommit_spec()
@@ -806,7 +719,7 @@ def ensure_vommit(ctx: Context) -> bool:
     # site-packages is already on sys.path, so the import finder just needs to
     # be told to look again.
     importlib.invalidate_caches()
-    if _vommit():
+    if vommit_tasks():
         return True
 
     cprint("vommit was installed but is not importable yet; please run this command again.", "yellow")
@@ -897,11 +810,11 @@ def _migrate_to_vommit(c: Context, pyproject: Path) -> Backend:
     """
     copy_pypi_token()
 
-    vommit_tasks = _vommit()
-    assert vommit_tasks, "ensure_vommit returned True without vommit being importable"
-    vommit_tasks.migrate(c, project_dir=str(pyproject.parent))
+    tasks = vommit_tasks()
+    assert tasks, "ensure_vommit returned True without vommit being importable"
+    tasks.migrate(c, project_dir=str(pyproject.parent))
 
-    if not _vommit_configured(pyproject):
+    if not vommit_configured(pyproject):
         cprint("Migration did not complete; releasing with python-semantic-release for now.", "yellow")
         return "psr"
 
@@ -912,26 +825,15 @@ def _setup_vommit(c: Context, pyproject: Path) -> Backend:
     """
     Run vommit's interactive setup on a project with no release config.
     """
-    vommit_tasks = _vommit()
-    assert vommit_tasks, "ensure_vommit returned True without vommit being importable"
-    vommit_tasks.setup(c, project_dir=str(pyproject.parent))
+    tasks = vommit_tasks()
+    assert tasks, "ensure_vommit returned True without vommit being importable"
+    tasks.setup(c, project_dir=str(pyproject.parent))
 
-    if not _vommit_configured(pyproject):
+    if not vommit_configured(pyproject):
         cprint("vommit was not configured; nothing to release with.", "yellow")
         return "none"
 
     return "vommit"
-
-
-def _vommit_configured(pyproject: Path) -> bool:
-    """
-    Whether vommit ended up with a config here.
-
-    vommit is importable by now, so ask vommit rather than re-parsing the file.
-    """
-    from vommit.config import Config
-
-    return Config.has_pyproject_config(pyproject)
 
 
 def _resolve_backend(c: Context, pyproject: Path = PYPROJECT) -> Optional[Backend]:
@@ -947,7 +849,7 @@ def _resolve_backend(c: Context, pyproject: Path = PYPROJECT) -> Optional[Backen
     if backend == "vommit":
         # vommit is an optional extra, so its config outlives its install: a
         # migrated project on a second machine has the one without the other.
-        if _vommit():
+        if vommit_tasks():
             return backend
 
         cprint(f"{pyproject} is configured for vommit, but vommit is not installed.", "yellow")
@@ -1040,8 +942,8 @@ def authenticate(_: Context):
         cprint("No token specified, exiting", "red")
         exit(1)
 
-    if not pypi_token.startswith("pypi-"):
-        cprint("Warning: PyPI tokens normally start with 'pypi-'.", "yellow")
+    if complaint := vommit_token_complaint(pypi_token):
+        cprint(complaint, "yellow")
 
     ensure_keyring_unlocked()
     keyring.set_password("edwh", "pypi", pypi_token)
@@ -1093,6 +995,8 @@ def _psr_bump(
     """
     Bump via python-semantic-release, installing it first if needed.
     """
+    # not a `pre=` on bump/release any more: a pre-task runs whatever the
+    # project is configured for, so a vommit project installed psr to release
     require_semantic_release(c)
 
     return _semantic_release_publish(
@@ -1125,11 +1029,10 @@ def bump(
 
     if backend is None:
         return None
-
-    if backend == "vommit":
-        vommit_tasks = _vommit()
-        assert vommit_tasks, "backend resolved to vommit without vommit being importable"
-        return vommit_tasks.bump(
+    elif backend == "vommit":
+        tasks = vommit_tasks()
+        assert tasks, "backend resolved to vommit without vommit being importable"
+        return tasks.bump(
             c,
             major=major,
             minor=minor,
@@ -1137,21 +1040,54 @@ def bump(
             prerelease=prerelease,
             noop=noop,
         )
-
-    if backend == "none":
-        # falling through here would install psr and run it against a project
-        # that has no psr config to run against
+    elif backend == "none":
+        # falling through would install psr and run it against a project that
+        # has no psr config to run against
         cprint("No release configuration; nothing to bump.", "yellow")
         return None
+    else:
+        return _psr_bump(
+            c,
+            major=major,
+            minor=minor,
+            patch=patch,
+            prerelease=prerelease,
+            noop=noop,
+            hide=hide,
+        )
 
-    return _psr_bump(
+
+def _vommit_release(
+    c: Context,
+    hatch: bool,
+    major: bool,
+    minor: bool,
+    patch: bool,
+    prerelease: bool,
+    noop: bool,
+    yes: bool,
+) -> None:
+    """
+    Hand a release to vommit.
+    """
+    if hatch:
+        cprint(
+            "--hatch has no meaning for a vommit project: set "
+            "[tool.vommit.commands] build/publish instead (e.g. `hatch build -c` / `hatch publish`).",
+            "red",
+        )
+        return
+
+    tasks = vommit_tasks()
+    assert tasks, "backend resolved to vommit without vommit being importable"
+    tasks.release(
         c,
         major=major,
         minor=minor,
         patch=patch,
         prerelease=prerelease,
         noop=noop,
-        hide=hide,
+        yes=yes,
     )
 
 
@@ -1196,20 +1132,10 @@ def release(
 
     if backend is None:
         return
-
-    if backend == "vommit":
-        if hatch:
-            cprint(
-                "--hatch has no meaning for a vommit project: set "
-                "[tool.vommit.commands] build/publish instead (e.g. `hatch build -c` / `hatch publish`).",
-                "red",
-            )
-            return
-
-        vommit_tasks = _vommit()
-        assert vommit_tasks, "backend resolved to vommit without vommit being importable"
-        vommit_tasks.release(
+    elif backend == "vommit":
+        return _vommit_release(
             c,
+            hatch=hatch,
             major=major,
             minor=minor,
             patch=patch,
@@ -1217,9 +1143,7 @@ def release(
             noop=noop,
             yes=yes,
         )
-        return
-
-    if backend == "none":
+    elif backend == "none":
         cprint("No release configuration; nothing to release with.", "yellow")
         return
 

--- a/src/edwh/local_tasks/plugin.py
+++ b/src/edwh/local_tasks/plugin.py
@@ -4,11 +4,16 @@ Extra namespace for plugin tasks such as plugin.add
 
 import concurrent.futures
 import datetime as dt
+import importlib
 import json
+import os
 import re
+import sys
+import types
 import typing
 from collections import OrderedDict
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Optional
 
 import dateutil.parser
@@ -22,7 +27,7 @@ from packaging.version import parse as parse_package_version
 from termcolor import colored, cprint
 from termcolor._types import Color
 
-from .. import confirm, kwargs_to_options
+from .. import confirm, interactive_selected_radio_value, kwargs_to_options
 from ..meta import (
     Version,
     _gather_package_metadata_threaded,
@@ -31,6 +36,17 @@ from ..meta import (
     _parse_versions,
     _pip,
     is_installed,
+)
+from ..release_backend import (
+    PYPROJECT,
+    Backend,
+    copy_pypi_token,
+    detect_backend,
+    enable_publishing,
+    pin_backend,
+    psr_uploaded,
+    store_vommit_pypi_token,
+    vommit_publishes,
 )
 
 
@@ -624,6 +640,11 @@ def changelog(ctx: Context, plugin: list[str], since: str = "5", new: bool = Fal
 
 
 def _semantic_release_publish(c: Context, flags: dict[str, typing.Any], **kw: typing.Any) -> typing.Optional[str]:
+    """
+    Run the deprecated python-semantic-release path.
+
+    Kept for projects that have not moved to vommit yet; see `release`.
+    """
     semver = c.run(f"semantic-release publish {kwargs_to_options(flags)}", **kw)
 
     matches: list[str] = re.findall(r"to (\d+\.\d+\.\d+.*)", semver.stderr if semver else "")
@@ -648,6 +669,8 @@ def uvenv(ctx: Context, specifier: str):
 def require_semantic_release(ctx: Context):
     """
     Task to ensure psr is available.
+
+    Part of the deprecated release path; new projects use vommit instead.
     """
     if is_installed(ctx, "semantic-release"):
         return
@@ -655,6 +678,230 @@ def require_semantic_release(ctx: Context):
     uvenv(ctx, "python-semantic-release<8")
 
     assert is_installed(ctx, "semantic-release"), "Tool 'semantic-release' still can't be found!"
+
+
+PSR_DEPRECATION = (
+    "python-semantic-release support is deprecated and will be removed in edwh 2.0. "
+    "Run `edwh plugin.release` again to migrate this project to vommit."
+)
+
+
+def _vommit() -> Optional[types.ModuleType]:
+    """
+    vommit's task module, or None when the `edwh[vommit]` extra isn't installed.
+
+    Its tasks take a Context and are callable in-process, which is why vommit is
+    a dependency rather than a tool we shell out to: `bump` hands back the new
+    version instead of us regex-scraping it out of another process' stderr.
+    """
+    try:
+        from vommit import tasks as vommit_tasks
+    except ImportError:
+        return None
+
+    return vommit_tasks
+
+
+def _vommit_spec() -> str:
+    """
+    What to install, taking edwh's keyring backend into account.
+
+    A plain `vommit` cannot read or write the ssh-agent-backed keyring, so a
+    project relying on it would install vommit and still be unable to reach its
+    own PyPI token.
+    """
+    from ..tasks import ssh_agent_keyring_config_path
+
+    return "vommit[ssh]" if ssh_agent_keyring_config_path().exists() else "vommit"
+
+
+@task()
+def require_vommit(ctx: Context) -> bool:
+    """
+    Ensure vommit is importable, offering to install it when it isn't.
+
+    Installs into edwh's own environment rather than via uvenv: that is what
+    activates vommit's `edwh` entry point, so `edwh vommit.*` starts working
+    too.
+    """
+    if _vommit():
+        return True
+
+    spec = _vommit_spec()
+    if not confirm(f"vommit is not installed. Install {spec} now? [Yn] ", default=True):
+        return False
+
+    ctx.run(f"{_pip()} install '{spec}'")
+
+    # site-packages is already on sys.path, so the import finder just needs to
+    # be told to look again.
+    importlib.invalidate_caches()
+    if _vommit():
+        return True
+
+    cprint("vommit was installed but is not importable yet; please run this command again.", "yellow")
+    return False
+
+
+SWITCH_NOW = "now"
+SWITCH_LATER = "later"
+SWITCH_NEVER = "never"
+
+MIGRATE_OPTIONS = {
+    SWITCH_NOW: "migrate now - walk through vommit's migrator, keeping your v7 settings",
+    SWITCH_LATER: "not now - release with python-semantic-release this time, ask again next time",
+    SWITCH_NEVER: "never - keep this project on python-semantic-release and stop asking",
+}
+
+SETUP_OPTIONS = {
+    SWITCH_NOW: "set up now - configure vommit for this project",
+    SWITCH_LATER: "not now - ask again next time",
+    SWITCH_NEVER: "never - stop asking about this project",
+}
+
+
+def _can_ask() -> bool:
+    """
+    Whether there is anybody to answer a radio prompt.
+
+    `confirm` honours EDWH_NON_INTERACTIVE itself, but the radio helper reads
+    the terminal directly and would hang or misread without this guard.
+    """
+    return os.environ.get("EDWH_NON_INTERACTIVE", "0") != "1" and sys.stdin.isatty()
+
+
+def _offer_switch(c: Context, backend: Backend, pyproject: Path) -> Backend:
+    """
+    Offer to move this project to vommit, and report which backend to use now.
+
+    Returns "vommit" only when a config was actually written: vommit's migrator
+    can be stopped halfway on purpose, and this release has to fall back rather
+    than hand over to a config that never landed.
+    """
+    migrating = backend == "psr"
+
+    if migrating:
+        cprint("This project still releases with python-semantic-release.", "blue")
+    else:
+        cprint("This project has no release configuration yet.", "blue")
+
+    if not _can_ask():
+        if not migrating:
+            cprint("Run `edwh plugin.release` interactively to set up vommit.", "blue")
+        return backend
+
+    prompt = "Switch this project to vommit?" if migrating else "Set this project up with vommit?"
+    answer = interactive_selected_radio_value(
+        MIGRATE_OPTIONS if migrating else SETUP_OPTIONS,
+        prompt=prompt,
+        selected=SWITCH_NOW,
+    )
+
+    if answer == SWITCH_NEVER:
+        pin_backend("psr" if migrating else "vommit", pyproject)
+        cprint(f"Recorded your choice in {pyproject}; edwh will not ask again.", "blue")
+        return backend
+
+    if answer != SWITCH_NOW:
+        # "not now", or the prompt was abandoned
+        return backend
+
+    if not require_vommit(c):
+        return backend
+
+    if migrating:
+        return _migrate_to_vommit(c, pyproject)
+
+    return _setup_vommit(c, pyproject)
+
+
+def _migrate_to_vommit(c: Context, pyproject: Path) -> Backend:
+    """
+    Copy the PyPI token across, run vommit's migrator, then repair publishing.
+    """
+    copy_pypi_token()
+
+    # psr's upload flags have to be read before the migrator strips its table
+    uploaded = psr_uploaded(pyproject)
+
+    vommit_tasks = _vommit()
+    assert vommit_tasks, "require_vommit returned True without vommit being importable"
+    vommit_tasks.migrate(c, project_dir=str(pyproject.parent))
+
+    if not _vommit_configured(pyproject):
+        cprint("Migration did not complete; releasing with python-semantic-release for now.", "yellow")
+        return "psr"
+
+    _restore_publishing(pyproject, psr_uploaded=uploaded)
+    return "vommit"
+
+
+def _setup_vommit(c: Context, pyproject: Path) -> Backend:
+    """
+    Run vommit's interactive setup on a project with no release config.
+    """
+    vommit_tasks = _vommit()
+    assert vommit_tasks, "require_vommit returned True without vommit being importable"
+    vommit_tasks.setup(c, project_dir=str(pyproject.parent))
+
+    if not _vommit_configured(pyproject):
+        cprint("vommit was not configured; nothing to release with.", "yellow")
+        return "none"
+
+    return "vommit"
+
+
+def _vommit_configured(pyproject: Path) -> bool:
+    """
+    Whether vommit ended up with a config here.
+
+    vommit is importable by now, so ask vommit rather than re-parsing the file.
+    """
+    from vommit.config import Config
+
+    return Config.has_pyproject_config(pyproject)
+
+
+def _restore_publishing(pyproject: Path, psr_uploaded: bool) -> None:
+    """
+    Put back the publishing step a faithful migration just removed.
+
+    psr was not uploading because `plugin.release` did it afterwards, so
+    `upload_to_repository = false` translates to `pypi.enabled = false` and the
+    project silently stops reaching PyPI. vommit cannot know that; we can.
+    """
+    if psr_uploaded or vommit_publishes(pyproject):
+        return
+
+    cprint(
+        "python-semantic-release was not uploading, so vommit turned publishing off. "
+        "But `plugin.release` was doing that upload, and vommit owns that step now.",
+        "yellow",
+    )
+    if confirm("Enable publishing (pypi.enabled = true)? [Yn] ", default=True):
+        enable_publishing(pyproject)
+        cprint("Enabled vommit's publishing step.", "green")
+    else:
+        cprint("Left publishing off: `vommit release` will bump, tag and push, but not publish.", "yellow")
+
+
+def _resolve_backend(c: Context, pyproject: Path = PYPROJECT) -> Backend:
+    """
+    Which backend releases this project, asking about a switch when relevant.
+
+    The single funnel for `release` and `bump`, so the deprecation notice lands
+    here once rather than at every place that could reach the psr path.
+    """
+    backend = detect_backend(pyproject)
+    if backend == "vommit":
+        return backend
+
+    backend = _offer_switch(c, backend, pyproject)
+
+    if backend == "psr":
+        cprint(PSR_DEPRECATION, "yellow")
+
+    return backend
 
 
 @task()
@@ -720,18 +967,43 @@ def build(c: Context, hatch: bool = False) -> list[str]:
 
 @task()
 def authenticate(_: Context):
-    if pypi_token := input("Enter your token (starting with pypi-): ").strip():
-        keyring.set_password("edwh", "pypi", pypi_token)
-        return pypi_token
-    else:
+    """
+    Store a PyPI token for releasing.
+
+    Written to both edwh's and vommit's keyring entries, so the token works
+    whichever backend a project uses.
+    """
+    from ..tasks import ensure_keyring_unlocked
+
+    pypi_token = input("Enter your token (starting with pypi-): ").strip()
+    if not pypi_token:
         cprint("No token specified, exiting", "red")
         exit(1)
+
+    if not pypi_token.startswith("pypi-"):
+        cprint("Warning: PyPI tokens normally start with 'pypi-'.", "yellow")
+
+    ensure_keyring_unlocked()
+    keyring.set_password("edwh", "pypi", pypi_token)
+
+    if store_vommit_pypi_token(pypi_token):
+        cprint("Stored the token for both edwh and vommit.", "green")
+    else:
+        cprint("Stored the token for edwh; run `vommit authenticate` too once vommit is installed.", "blue")
+
+    return pypi_token
 
 
 def publish(c: Context, hatch: bool = False):
     if hatch:
         c.run("hatch publish")
     else:
+        from ..tasks import ensure_keyring_unlocked
+
+        # without this a locked keyring raises instead of offering the ssh-agent
+        # fallback, which is exactly when a release needs the token most
+        ensure_keyring_unlocked()
+
         pypi_token = keyring.get_password("edwh", "pypi")
         if not pypi_token:
             pypi_token = authenticate(c)
@@ -743,8 +1015,7 @@ def publish(c: Context, hatch: bool = False):
             cprint("Hint: you may want to enter a new token via `edwh plugin.authenticate`", "blue")
 
 
-@task(pre=[require_semantic_release])
-def bump(
+def _psr_bump(
     c: Context,
     major: bool = False,
     minor: bool = False,
@@ -752,7 +1023,12 @@ def bump(
     prerelease: bool = False,
     noop: bool = False,
     hide: bool = False,
-):
+) -> Optional[str]:
+    """
+    Bump via python-semantic-release, installing it first if needed.
+    """
+    require_semantic_release(c)
+
     return _semantic_release_publish(
         c,
         {
@@ -766,7 +1042,43 @@ def bump(
     )
 
 
-@task(aliases=("publish",), pre=[require_semantic_release])
+@task()
+def bump(
+    c: Context,
+    major: bool = False,
+    minor: bool = False,
+    patch: bool = False,
+    prerelease: bool = False,
+    noop: bool = False,
+    hide: bool = False,
+) -> Optional[str]:
+    """
+    Bump this project's version, using whichever release tool it is configured for.
+    """
+    if _resolve_backend(c) == "vommit":
+        vommit_tasks = _vommit()
+        assert vommit_tasks, "backend resolved to vommit without vommit being importable"
+        return vommit_tasks.bump(
+            c,
+            major=major,
+            minor=minor,
+            patch=patch,
+            prerelease=prerelease,
+            noop=noop,
+        )
+
+    return _psr_bump(
+        c,
+        major=major,
+        minor=minor,
+        patch=patch,
+        prerelease=prerelease,
+        noop=noop,
+        hide=hide,
+    )
+
+
+@task(aliases=("publish",))
 def release(
     c: Context,
     noop: bool = False,
@@ -793,9 +1105,6 @@ def release(
         yes: don't ask for confirmation
         hatch: backwards-compatibility for when 'uv' doesn't work.
     """
-    if hatch:
-        require_hatch(c)
-
     if pull:
         try:
             git_pull(c, yes=yes)
@@ -803,10 +1112,44 @@ def release(
             # stop
             return
 
+    # git_pull runs first on both paths: vommit only fetches for its branch
+    # check, so resolving the backend before pulling would change what --pull
+    # means for a project that migrates during this very run.
+    backend = _resolve_backend(c)
+
+    if backend == "vommit":
+        if hatch:
+            cprint(
+                "--hatch has no meaning for a vommit project: set "
+                "[tool.vommit.commands] build/publish instead (e.g. `hatch build -c` / `hatch publish`).",
+                "red",
+            )
+            return
+
+        vommit_tasks = _vommit()
+        assert vommit_tasks, "backend resolved to vommit without vommit being importable"
+        vommit_tasks.release(
+            c,
+            major=major,
+            minor=minor,
+            patch=patch,
+            prerelease=prerelease,
+            noop=noop,
+            yes=yes,
+        )
+        return
+
+    if backend == "none":
+        cprint("No release configuration; nothing to release with.", "yellow")
+        return
+
+    if hatch:
+        require_hatch(c)
+
     cprint("bumping version", "blue")
 
     if not (yes or noop):
-        new_version = bump(
+        new_version = _psr_bump(
             c,
             major=major,
             minor=minor,
@@ -822,7 +1165,7 @@ def release(
             print("bye!")
             return
 
-    new_version = bump(
+    new_version = _psr_bump(
         c,
         major=major,
         minor=minor,

--- a/src/edwh/local_tasks/plugin.py
+++ b/src/edwh/local_tasks/plugin.py
@@ -9,7 +9,6 @@ import json
 import os
 import re
 import sys
-import types
 import typing
 from collections import OrderedDict
 from dataclasses import dataclass
@@ -36,6 +35,8 @@ from ..meta import (
     _parse_versions,
     _pip,
     is_installed,
+    pip_install,
+    pip_uninstall,
 )
 from ..release_backend import (
     PYPROJECT,
@@ -253,11 +254,9 @@ def add_all(c: Context) -> None:
     Args:
         c (Context): invoke ctx
     """
-    pip = _pip()
     plugins = _get_available_plugins_from_pypi("edwh", "plugins")
 
-    plugins_joined = " ".join(plugins)
-    c.run(f"{pip} install {plugins_joined}")
+    pip_install(c, *plugins)
 
 
 @task()
@@ -268,11 +267,9 @@ def remove_all(c: Context) -> None:
     Args:
         c (Context): invoke ctx
     """
-    pip = _pip()
     plugins = _get_available_plugins_from_pypi("edwh", "plugins")
 
-    plugins_joined = " ".join(plugins)
-    c.run(f"{pip} uninstall {plugins_joined}")
+    pip_uninstall(c, *plugins)
 
 
 @task(aliases=("install",))
@@ -289,11 +286,9 @@ def add(c: Context, plugin_names: str) -> None:
     if plugin_names == "all":
         return add_all(c)
 
-    pip = _pip()
-
     plugin_names_splitted = [_require_affixes(plugin_name.strip()) for plugin_name in plugin_names.split(",")]
 
-    c.run(f"{pip} install " + " ".join(plugin_names_splitted))
+    pip_install(c, *plugin_names_splitted)
 
 
 @task(aliases=("upgrade",))
@@ -318,8 +313,6 @@ def update(
 
         return self_update(c, no_cache=force)
 
-    pip = _pip()
-
     plugins_with_version = []
     for plugin_name in plugin_names.split(","):
         plugin_name = _require_affixes(plugin_name.strip())
@@ -329,7 +322,7 @@ def update(
     if verbose:
         cprint(str(plugins_with_version), "blue")
 
-    c.run(f"{pip} install " + " ".join(plugins_with_version))
+    pip_install(c, *plugins_with_version)
 
 
 @task(aliases=("uninstall",))
@@ -344,11 +337,10 @@ def remove(c: Context, plugin_names: str) -> None:
     if plugin_names == "all":
         return remove_all(c)
 
-    pip = _pip()
     # ensure the prefix and suffix exist, but not twice:
     plugin_names_splitted = [_require_affixes(plugin_name.strip()) for plugin_name in plugin_names.split(",")]
 
-    c.run(f"{pip} uninstall " + " ".join(plugin_names_splitted))
+    pip_uninstall(c, *plugin_names_splitted)
 
 
 GITHUB_RAW_URL = yarl.URL("https://raw.githubusercontent.com")
@@ -686,12 +678,52 @@ PSR_DEPRECATION = (
 )
 
 
-def _vommit() -> Optional[types.ModuleType]:
+class VommitTasks(typing.Protocol):
     """
-    vommit's task module, or None when the `edwh[vommit]` extra isn't installed.
+    The four vommit tasks we call, and the arguments we call them with.
 
-    Its tasks take a Context and are callable in-process, which is why vommit is
-    a dependency rather than a tool we shell out to: `bump` hands back the new
+    Spelled out rather than typed as a module, so a mistake in a keyword or a
+    reshape on vommit's side is a type error here instead of an AttributeError
+    during someone's release. `tests/test_release_backend.py` checks the real
+    signatures still match.
+    """
+
+    def setup(self, c: Context, /, *, project_dir: str) -> None: ...
+
+    def migrate(self, c: Context, /, *, project_dir: str) -> None: ...
+
+    def bump(
+        self,
+        c: Context,
+        /,
+        *,
+        major: bool = False,
+        minor: bool = False,
+        patch: bool = False,
+        prerelease: bool = False,
+        noop: bool = False,
+    ) -> Optional[str]: ...
+
+    def release(
+        self,
+        c: Context,
+        /,
+        *,
+        major: bool = False,
+        minor: bool = False,
+        patch: bool = False,
+        prerelease: bool = False,
+        noop: bool = False,
+        yes: bool = False,
+    ) -> Optional[str]: ...
+
+
+def _vommit() -> Optional[VommitTasks]:
+    """
+    vommit's tasks, or None when the `edwh[vommit]` extra isn't installed.
+
+    They take a Context and are callable in-process, which is why vommit is a
+    dependency rather than a tool we shell out to: `bump` hands back the new
     version instead of us regex-scraping it out of another process' stderr.
     """
     try:
@@ -699,7 +731,7 @@ def _vommit() -> Optional[types.ModuleType]:
     except ImportError:
         return None
 
-    return vommit_tasks
+    return typing.cast(VommitTasks, vommit_tasks)
 
 
 def _vommit_spec() -> str:
@@ -731,7 +763,7 @@ def require_vommit(ctx: Context) -> bool:
     if not confirm(f"vommit is not installed. Install {spec} now? [Yn] ", default=True):
         return False
 
-    ctx.run(f"{_pip()} install '{spec}'")
+    pip_install(ctx, spec)
 
     # site-packages is already on sys.path, so the import finder just needs to
     # be told to look again.
@@ -801,12 +833,10 @@ def _offer_switch(c: Context, backend: Backend, pyproject: Path) -> Backend:
         pin_backend("psr" if migrating else "vommit", pyproject)
         cprint(f"Recorded your choice in {pyproject}; edwh will not ask again.", "blue")
         return backend
-
-    if answer != SWITCH_NOW:
+    elif answer != SWITCH_NOW:
         # "not now", or the prompt was abandoned
         return backend
-
-    if not require_vommit(c):
+    elif not require_vommit(c):
         return backend
 
     if migrating:
@@ -908,6 +938,9 @@ def _resolve_backend(c: Context, pyproject: Path = PYPROJECT) -> Backend:
 def require_hatch(ctx: Context):
     """
     Task to ensure hatch is available.
+
+    Part of the deprecated release path; vommit projects set
+    [tool.vommit.commands] build/publish instead of passing --hatch.
     """
     if is_installed(ctx, "hatch"):
         return
@@ -995,6 +1028,12 @@ def authenticate(_: Context):
 
 
 def publish(c: Context, hatch: bool = False):
+    """
+    Upload a build, as the deprecated psr path does it.
+
+    Only reachable from `release`'s psr branch, which prints PSR_DEPRECATION
+    before it gets here; vommit projects publish via [tool.vommit.commands].
+    """
     if hatch:
         c.run("hatch publish")
     else:

--- a/src/edwh/meta.py
+++ b/src/edwh/meta.py
@@ -9,6 +9,7 @@ import typing as t
 
 import yayarl as yarl
 from ewok import Context, task
+from invoke.runners import Result
 from packaging.version import InvalidVersion, Version
 from packaging.version import parse as parse_package_version
 from termcolor import cprint
@@ -33,14 +34,14 @@ def _pip(python: str = _python()) -> str:
     return f"{python} -m uv pip"
 
 
-def pip_install(c: Context, *specifiers: str, **kw: t.Any) -> t.Any:
+def pip_install(c: Context, *specifiers: str, **kw: t.Any) -> t.Optional[Result]:
     """
     Install into the environment edwh itself runs in.
     """
     return c.run(f"{_pip()} install {shlex.join(specifiers)}", **kw)
 
 
-def pip_uninstall(c: Context, *specifiers: str, **kw: t.Any) -> t.Any:
+def pip_uninstall(c: Context, *specifiers: str, **kw: t.Any) -> t.Optional[Result]:
     """
     Remove from the environment edwh itself runs in.
     """

--- a/src/edwh/meta.py
+++ b/src/edwh/meta.py
@@ -3,6 +3,7 @@ This files contains everything to do with meta-tasks such as self-updating
 """
 
 import concurrent.futures
+import shlex
 import sys
 import typing as t
 
@@ -30,6 +31,20 @@ def _pip(python: str = _python()) -> str:
     """
     # uv.find_uv_bin() does not really work here, because then the right venv may not be used!
     return f"{python} -m uv pip"
+
+
+def pip_install(c: Context, *specifiers: str, **kw: t.Any) -> t.Any:
+    """
+    Install into the environment edwh itself runs in.
+    """
+    return c.run(f"{_pip()} install {shlex.join(specifiers)}", **kw)
+
+
+def pip_uninstall(c: Context, *specifiers: str, **kw: t.Any) -> t.Any:
+    """
+    Remove from the environment edwh itself runs in.
+    """
+    return c.run(f"{_pip()} uninstall {shlex.join(specifiers)}", **kw)
 
 
 def _get_pypi_info(package: str) -> AnyDict:

--- a/src/edwh/release_backend.py
+++ b/src/edwh/release_backend.py
@@ -1,0 +1,258 @@
+"""
+Which release tool owns a project, and what it takes to move it to vommit.
+
+`plugin.release` used to mean "run python-semantic-release". It now routes: a
+project configured for vommit is released by vommit, a project still on psr is
+offered a migration, and a project with neither is offered a first-time setup.
+Deciding which of those applies has to work *before* vommit is installed, so
+the detection here is deliberately edwh's own rather than a call into
+`vommit.migrate` -- it is three key lookups, and it buys the ability to leave
+vommit uninstalled on projects that will never want it. Everything downstream
+of the prompt imports from vommit instead of reimplementing it.
+
+Reads go through `tomllib` (like `enabled_lint_tools`), writes through
+`tomlkit`, so a project's comments and formatting survive being pinned.
+"""
+
+import tomllib
+import typing as t
+from pathlib import Path
+
+import keyring
+import keyring.errors
+import tomlkit
+from termcolor import cprint
+
+# Where each tool keeps its configuration.
+PSR_KEY = ("tool", "semantic_release")
+VOMMIT_KEY = ("tool", "vommit")
+# Our own opt-out, alongside [tool.edwh.lint].
+PIN_KEY = ("tool", "edwh", "release")
+
+# edwh's PyPI token, as `plugin.authenticate` has always stored it.
+EDWH_KEYRING_SERVICE = "edwh"
+EDWH_KEYRING_USERNAME = "pypi"
+
+PYPROJECT = Path("pyproject.toml")
+
+type Backend = t.Literal["vommit", "psr", "none"]
+
+# The psr keys that meant "do not upload"; edwh's convention set them because
+# `plugin.release` did the uploading itself.
+PSR_UPLOAD_KEYS = ("upload_to_repository", "upload_to_pypi")
+
+
+def _load(pyproject: Path) -> dict[str, t.Any]:
+    """
+    The pyproject as a plain dict, or empty when it is missing or unreadable.
+
+    Unreadable counts as empty on purpose: a broken pyproject is a problem for
+    the build backend to report, not a reason for `plugin.release` to traceback
+    before it has said anything useful.
+    """
+    if not pyproject.exists():
+        return {}
+
+    try:
+        return tomllib.loads(pyproject.read_text())
+    except (tomllib.TOMLDecodeError, OSError, UnicodeDecodeError):
+        return {}
+
+
+def _nested(document: t.Mapping[str, t.Any], path: t.Sequence[str]) -> t.Any:
+    """
+    Follow a dotted key path, returning None as soon as it stops being a table.
+    """
+    current: t.Any = document
+    for key in path:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(key)
+
+    return current
+
+
+def has_psr_config(pyproject: Path = PYPROJECT) -> bool:
+    """
+    Whether this project still carries a [tool.semantic_release] table.
+    """
+    return isinstance(_nested(_load(pyproject), PSR_KEY), dict)
+
+
+def has_vommit_config(pyproject: Path = PYPROJECT) -> bool:
+    """
+    Whether this project carries a [tool.vommit] table.
+
+    Deliberately not `vommit.config.Config.has_pyproject_config`: this question
+    gets asked while vommit may not be importable yet.
+    """
+    return isinstance(_nested(_load(pyproject), VOMMIT_KEY), dict)
+
+
+def pinned_backend(pyproject: Path = PYPROJECT) -> str | None:
+    """
+    The backend this project has been pinned to, if any.
+
+        [tool.edwh.release]
+        backend = "psr"
+    """
+    pin = _nested(_load(pyproject), PIN_KEY)
+    if not isinstance(pin, dict):
+        return None
+
+    backend = pin.get("backend")
+    return backend if isinstance(backend, str) else None
+
+
+def detect_backend(pyproject: Path = PYPROJECT) -> Backend:
+    """
+    Which tool should release this project.
+
+    A present [tool.vommit] wins over a pin, so migrating by hand is honoured
+    without also having to remove the opt-out. Otherwise a pin is final -- that
+    is the whole point of answering "never" -- and only then does a psr config
+    lead to the migration offer.
+    """
+    if has_vommit_config(pyproject):
+        return "vommit"
+
+    match pinned_backend(pyproject):
+        case "vommit":
+            # pinned to vommit but not configured for it yet: setup, not psr
+            return "none"
+        case "psr":
+            return "psr"
+
+    return "psr" if has_psr_config(pyproject) else "none"
+
+
+def psr_uploaded(pyproject: Path = PYPROJECT) -> bool:
+    """
+    Whether psr itself was uploading this project to an index.
+
+    Must be read *before* migrating, because vommit strips the table. When psr
+    was not uploading, vommit's translation faithfully turns publishing off --
+    and that is wrong for us, because the uploading was `plugin.release`'s job
+    all along. See `enable_publishing`.
+    """
+    psr = _nested(_load(pyproject), PSR_KEY)
+    if not isinstance(psr, dict):
+        # no psr config at all: nothing was disabled, so nothing to restore
+        return True
+
+    # v7 defaulted both to true; either one set to false stopped the upload.
+    return all(psr.get(key, True) is not False for key in PSR_UPLOAD_KEYS)
+
+
+def vommit_publishes(pyproject: Path = PYPROJECT) -> bool:
+    """
+    Whether a migrated project would actually publish.
+    """
+    pypi = _nested(_load(pyproject), (*VOMMIT_KEY, "pypi"))
+    if not isinstance(pypi, dict):
+        # the section is absent, which vommit reads as enabled
+        return True
+
+    return pypi.get("enabled", True) is not False
+
+
+def _edit(pyproject: Path) -> tuple[tomlkit.TOMLDocument, t.Callable[[], None]]:
+    """
+    A tomlkit document plus the call that writes it back.
+    """
+    document = tomlkit.parse(pyproject.read_text()) if pyproject.exists() else tomlkit.document()
+
+    def save() -> None:
+        pyproject.write_text(tomlkit.dumps(document))
+
+    return document, save
+
+
+def _table(document: tomlkit.TOMLDocument, path: t.Sequence[str]) -> t.Any:
+    """
+    Reach (creating as needed) the table at a dotted key path.
+    """
+    current: t.Any = document
+    for key in path:
+        if key not in current:
+            current[key] = tomlkit.table()
+        current = current[key]
+
+    return current
+
+
+def pin_backend(backend: Backend, pyproject: Path = PYPROJECT) -> None:
+    """
+    Record the release backend in the project, so we stop asking.
+    """
+    document, save = _edit(pyproject)
+    _table(document, PIN_KEY)["backend"] = backend
+    save()
+
+
+def enable_publishing(pyproject: Path = PYPROJECT) -> None:
+    """
+    Turn vommit's publishing step back on after a migration turned it off.
+    """
+    document, save = _edit(pyproject)
+    _table(document, (*VOMMIT_KEY, "pypi"))["enabled"] = True
+    save()
+
+
+def edwh_pypi_token() -> str | None:
+    """
+    The PyPI token `plugin.authenticate` stored, or None when there is none.
+    """
+    try:
+        return keyring.get_password(EDWH_KEYRING_SERVICE, EDWH_KEYRING_USERNAME)
+    except keyring.errors.KeyringError:
+        return None
+
+
+def store_vommit_pypi_token(token: str) -> bool:
+    """
+    Put a token where vommit looks for it, without hardcoding where that is.
+
+    `TokenStore` defaults to vommit's own service and username, so the two
+    packages cannot drift apart on the name, and its keyring errors arrive
+    already translated.
+    """
+    try:
+        from vommit.auth import TokenStore
+    except ImportError:
+        return False
+
+    try:
+        TokenStore().store(token)
+    except Exception:
+        # a keyring vommit cannot write to is not a reason to abort a release
+        return False
+
+    return True
+
+
+def copy_pypi_token() -> bool:
+    """
+    Copy edwh's PyPI token into vommit's keyring, leaving edwh's entry alone.
+
+    Keeping both means a half-finished migration can still release the old way.
+    Returns whether vommit now has a token to publish with; a False is a nudge
+    towards `vommit authenticate`, never a failure worth stopping for.
+    """
+    from .tasks import ensure_keyring_unlocked
+
+    if not ensure_keyring_unlocked():
+        cprint("Keyring unavailable; run `vommit authenticate` to store your PyPI token.", "yellow")
+        return False
+
+    token = edwh_pypi_token()
+    if not token:
+        cprint("No PyPI token in edwh's keyring; run `vommit authenticate` when you release.", "blue")
+        return False
+
+    if not store_vommit_pypi_token(token):
+        cprint("Could not write to vommit's keyring; run `vommit authenticate` instead.", "yellow")
+        return False
+
+    cprint("Copied your PyPI token to vommit's keyring (edwh's copy is untouched).", "green")
+    return True

--- a/src/edwh/release_backend.py
+++ b/src/edwh/release_backend.py
@@ -1,27 +1,23 @@
 """
-Which release tool owns a project, and what it takes to move it to vommit.
+Which release tool owns a project, and everything edwh asks of vommit.
 
-`plugin.release` used to mean "run python-semantic-release". It now routes: a
-project configured for vommit is released by vommit, a project still on psr is
-offered a migration, and a project with neither is offered a first-time setup.
-Deciding which of those applies has to work *before* vommit is installed, so
-the detection here is deliberately edwh's own rather than a call into
-`vommit.migrate` -- it is three key lookups, and it buys the ability to leave
-vommit uninstalled on projects that will never want it. Everything downstream
-of the prompt imports from vommit instead of reimplementing it.
-
-Reads go through `tomllib` (like `enabled_lint_tools`), writes through
-`tomlkit`, so a project's comments and formatting survive being pinned.
+Detection is edwh's own because it has to answer "should I offer to install
+vommit?" before vommit exists; every other call in here goes to vommit. Those
+imports are deferred on purpose -- the extra is optional, so importing at module
+level would make edwh itself unimportable without it.
 """
 
 import tomllib
 import typing as t
 from contextlib import contextmanager
+from importlib.metadata import PackageNotFoundError, requires
 from pathlib import Path
 
 import keyring
 import keyring.errors
 import tomlkit
+from ewok import Context
+from packaging.requirements import InvalidRequirement, Requirement
 from termcolor import cprint
 
 # Where each tool keeps its configuration.
@@ -33,6 +29,9 @@ PIN_KEY = ("tool", "edwh", "release")
 # edwh's PyPI token, as `plugin.authenticate` has always stored it.
 EDWH_KEYRING_SERVICE = "edwh"
 EDWH_KEYRING_USERNAME = "pypi"
+
+# Only used when edwh's metadata cannot be read, i.e. an uninstalled source tree.
+VOMMIT_FALLBACK_SPECIFIER = ">=0.1.1,<1"
 
 PYPROJECT = Path("pyproject.toml")
 
@@ -157,6 +156,119 @@ def pin_backend(backend: Backend, pyproject: Path = PYPROJECT) -> None:
     """
     with _edit(pyproject) as document:
         _table(document, PIN_KEY)["backend"] = backend
+
+
+class VommitTasks(t.Protocol):
+    """
+    The vommit tasks edwh calls, and the arguments it calls them with.
+
+    Spelled out rather than typed as a module, so a wrong keyword is a type
+    error here instead of an AttributeError during someone's release.
+    `tests/test_release_backend.py` checks the real signatures still match.
+    """
+
+    def setup(self, c: Context, /, *, project_dir: str) -> None: ...
+
+    def migrate(self, c: Context, /, *, project_dir: str) -> None: ...
+
+    def bump(
+        self,
+        c: Context,
+        /,
+        *,
+        major: bool = False,
+        minor: bool = False,
+        patch: bool = False,
+        prerelease: bool = False,
+        noop: bool = False,
+    ) -> str | None: ...
+
+    def release(
+        self,
+        c: Context,
+        /,
+        *,
+        major: bool = False,
+        minor: bool = False,
+        patch: bool = False,
+        prerelease: bool = False,
+        noop: bool = False,
+        yes: bool = False,
+    ) -> str | None: ...
+
+
+def vommit_tasks() -> VommitTasks | None:
+    """
+    vommit's tasks, or None when the `edwh[vommit]` extra isn't installed.
+
+    They take a Context and are callable in-process, which is why vommit is a
+    dependency rather than a tool we shell out to: `bump` hands back the new
+    version instead of us regex-scraping it out of another process' stderr.
+    """
+    try:
+        from vommit import tasks
+    except ImportError:
+        return None
+
+    return t.cast(VommitTasks, tasks)
+
+
+def vommit_configured(pyproject: Path = PYPROJECT) -> bool:
+    """
+    Whether vommit ended up with a config here, according to vommit.
+
+    Unlike `has_vommit_config`, this needs vommit installed -- it is for after
+    the migrator has run, when it is.
+    """
+    from vommit.config import Config
+
+    return Config.has_pyproject_config(pyproject)
+
+
+def vommit_specifier() -> str:
+    """
+    The version range the `vommit` extra declares.
+
+    Read from edwh's metadata rather than written down twice, so widening the
+    extra cannot leave the install prompt behind on the old range. The fallback
+    covers a source tree that was never installed, whose metadata is absent.
+    """
+    try:
+        declared = requires("edwh") or ()
+    except PackageNotFoundError:
+        return VOMMIT_FALLBACK_SPECIFIER
+
+    for requirement in declared:
+        try:
+            parsed = Requirement(requirement)
+        except InvalidRequirement:
+            continue
+
+        if parsed.name == "vommit" and parsed.marker and parsed.marker.evaluate({"extra": "vommit"}):
+            return str(parsed.specifier)
+
+    return VOMMIT_FALLBACK_SPECIFIER
+
+
+def vommit_token_complaint(token: str) -> str | None:
+    """
+    vommit's verdict on a token's format, or None when it has nothing to say.
+
+    Delegated rather than re-checked here: vommit already knows what a usable
+    token looks like, and its message says more than "should start with pypi-".
+    """
+    try:
+        from vommit.auth import check_format
+        from vommit.errors import VommitError
+    except ImportError:
+        return None
+
+    try:
+        check_format(token)
+    except VommitError as complaint:
+        return str(complaint)
+
+    return None
 
 
 def edwh_pypi_token() -> str | None:

--- a/src/edwh/release_backend.py
+++ b/src/edwh/release_backend.py
@@ -16,6 +16,7 @@ Reads go through `tomllib` (like `enabled_lint_tools`), writes through
 
 import tomllib
 import typing as t
+from contextlib import contextmanager
 from pathlib import Path
 
 import keyring
@@ -156,16 +157,19 @@ def vommit_publishes(pyproject: Path = PYPROJECT) -> bool:
     return pypi.get("enabled", True) is not False
 
 
-def _edit(pyproject: Path) -> tuple[tomlkit.TOMLDocument, t.Callable[[], None]]:
+@contextmanager
+def _edit(pyproject: Path) -> t.Iterator[tomlkit.TOMLDocument]:
     """
-    A tomlkit document plus the call that writes it back.
+    Edit a pyproject in place, keeping its comments and formatting.
+
+    Written back on a clean exit only, so a failure part-way leaves the file
+    as it was rather than half-updated.
     """
     document = tomlkit.parse(pyproject.read_text()) if pyproject.exists() else tomlkit.document()
 
-    def save() -> None:
-        pyproject.write_text(tomlkit.dumps(document))
+    yield document
 
-    return document, save
+    pyproject.write_text(tomlkit.dumps(document))
 
 
 def _table(document: tomlkit.TOMLDocument, path: t.Sequence[str]) -> t.Any:
@@ -185,18 +189,16 @@ def pin_backend(backend: Backend, pyproject: Path = PYPROJECT) -> None:
     """
     Record the release backend in the project, so we stop asking.
     """
-    document, save = _edit(pyproject)
-    _table(document, PIN_KEY)["backend"] = backend
-    save()
+    with _edit(pyproject) as document:
+        _table(document, PIN_KEY)["backend"] = backend
 
 
 def enable_publishing(pyproject: Path = PYPROJECT) -> None:
     """
     Turn vommit's publishing step back on after a migration turned it off.
     """
-    document, save = _edit(pyproject)
-    _table(document, (*VOMMIT_KEY, "pypi"))["enabled"] = True
-    save()
+    with _edit(pyproject) as document:
+        _table(document, (*VOMMIT_KEY, "pypi"))["enabled"] = True
 
 
 def edwh_pypi_token() -> str | None:

--- a/src/edwh/release_backend.py
+++ b/src/edwh/release_backend.py
@@ -38,10 +38,6 @@ PYPROJECT = Path("pyproject.toml")
 
 type Backend = t.Literal["vommit", "psr", "none"]
 
-# The psr keys that meant "do not upload"; edwh's convention set them because
-# `plugin.release` did the uploading itself.
-PSR_UPLOAD_KEYS = ("upload_to_repository", "upload_to_pypi")
-
 
 def _load(pyproject: Path) -> dict[str, t.Any]:
     """
@@ -127,36 +123,6 @@ def detect_backend(pyproject: Path = PYPROJECT) -> Backend:
     return "psr" if has_psr_config(pyproject) else "none"
 
 
-def psr_uploaded(pyproject: Path = PYPROJECT) -> bool:
-    """
-    Whether psr itself was uploading this project to an index.
-
-    Must be read *before* migrating, because vommit strips the table. When psr
-    was not uploading, vommit's translation faithfully turns publishing off --
-    and that is wrong for us, because the uploading was `plugin.release`'s job
-    all along. See `enable_publishing`.
-    """
-    psr = _nested(_load(pyproject), PSR_KEY)
-    if not isinstance(psr, dict):
-        # no psr config at all: nothing was disabled, so nothing to restore
-        return True
-
-    # v7 defaulted both to true; either one set to false stopped the upload.
-    return all(psr.get(key, True) is not False for key in PSR_UPLOAD_KEYS)
-
-
-def vommit_publishes(pyproject: Path = PYPROJECT) -> bool:
-    """
-    Whether a migrated project would actually publish.
-    """
-    pypi = _nested(_load(pyproject), (*VOMMIT_KEY, "pypi"))
-    if not isinstance(pypi, dict):
-        # the section is absent, which vommit reads as enabled
-        return True
-
-    return pypi.get("enabled", True) is not False
-
-
 @contextmanager
 def _edit(pyproject: Path) -> t.Iterator[tomlkit.TOMLDocument]:
     """
@@ -191,14 +157,6 @@ def pin_backend(backend: Backend, pyproject: Path = PYPROJECT) -> None:
     """
     with _edit(pyproject) as document:
         _table(document, PIN_KEY)["backend"] = backend
-
-
-def enable_publishing(pyproject: Path = PYPROJECT) -> None:
-    """
-    Turn vommit's publishing step back on after a migration turned it off.
-    """
-    with _edit(pyproject) as document:
-        _table(document, (*VOMMIT_KEY, "pypi"))["enabled"] = True
 
 
 def edwh_pypi_token() -> str | None:

--- a/tests/test_release_backend.py
+++ b/tests/test_release_backend.py
@@ -11,11 +11,8 @@ import pytest
 
 from src.edwh.release_backend import (
     detect_backend,
-    enable_publishing,
     pin_backend,
     pinned_backend,
-    psr_uploaded,
-    vommit_publishes,
 )
 
 PSR = """[project]
@@ -107,34 +104,6 @@ def test_pin_alongside_existing_tool_edwh_table(tmp_path):
     text = pyproject.read_text()
     assert "ty = false" in text
     assert pinned_backend(pyproject) == "psr"
-
-
-@pytest.mark.parametrize(
-    "table,uploaded",
-    [
-        ("", True),  # no psr config: nothing was disabled
-        ("[tool.semantic_release]\nbranch = 'main'\n", True),  # v7 defaulted to true
-        ("[tool.semantic_release]\nupload_to_repository = false\n", False),
-        ("[tool.semantic_release]\nupload_to_pypi = false\n", False),
-    ],
-)
-def test_psr_uploaded(tmp_path, table, uploaded):
-    """Read before migrating: vommit strips the table it is derived from."""
-    assert psr_uploaded(write(tmp_path, f'[project]\nname = "demo"\n\n{table}')) is uploaded
-
-
-def test_enable_publishing_restores_the_step_migration_removed(tmp_path):
-    """psr wasn't uploading because plugin.release was; vommit owns that now."""
-    pyproject = write(tmp_path, VOMMIT + "\n[tool.vommit.pypi]\nenabled = false\n")
-    assert vommit_publishes(pyproject) is False
-
-    enable_publishing(pyproject)
-
-    assert vommit_publishes(pyproject) is True
-
-
-def test_publishing_defaults_to_on_without_a_pypi_section(tmp_path):
-    assert vommit_publishes(write(tmp_path, VOMMIT)) is True
 
 
 def test_vommit_tasks_accept_the_arguments_we_pass():

--- a/tests/test_release_backend.py
+++ b/tests/test_release_backend.py
@@ -9,7 +9,7 @@ import inspect
 
 import pytest
 
-from edwh.release_backend import (
+from src.edwh.release_backend import (
     detect_backend,
     enable_publishing,
     pin_backend,

--- a/tests/test_release_backend.py
+++ b/tests/test_release_backend.py
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: 2023-present Remco Boerma <remco.b@educationwarehouse.nl>
+#
+# SPDX-License-Identifier: MIT
+"""
+Which release tool owns a project, and whether we can pin that choice.
+"""
+
+import inspect
+
+import pytest
+
+from edwh.release_backend import (
+    detect_backend,
+    enable_publishing,
+    pin_backend,
+    pinned_backend,
+    psr_uploaded,
+    vommit_publishes,
+)
+
+PSR = """[project]
+name = "demo"
+
+[tool.semantic_release]
+branch = "main"
+version_variable = "src/demo/__about__.py:__version__"
+upload_to_repository = false
+"""
+
+VOMMIT = """[project]
+name = "demo"
+version = "1.0.0"
+
+[tool.vommit]
+prerelease_token = "beta"
+"""
+
+
+def write(tmp_path, content: str):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(content)
+    return pyproject
+
+
+def test_detects_psr_config(tmp_path):
+    assert detect_backend(write(tmp_path, PSR)) == "psr"
+
+
+def test_detects_vommit_config(tmp_path):
+    assert detect_backend(write(tmp_path, VOMMIT)) == "vommit"
+
+
+def test_project_without_release_config_needs_setup(tmp_path):
+    assert detect_backend(write(tmp_path, '[project]\nname = "demo"\n')) == "none"
+
+
+def test_missing_pyproject_needs_setup(tmp_path):
+    assert detect_backend(tmp_path / "pyproject.toml") == "none"
+
+
+def test_malformed_pyproject_does_not_raise(tmp_path):
+    """A broken pyproject is the build backend's problem to report, not ours."""
+    assert detect_backend(write(tmp_path, "[project\nname = ")) == "none"
+
+
+def test_pin_stops_the_migration_offer(tmp_path):
+    """Answering 'never' has to survive into the next release."""
+    pyproject = write(tmp_path, PSR)
+    pin_backend("psr", pyproject)
+
+    assert pinned_backend(pyproject) == "psr"
+    assert detect_backend(pyproject) == "psr"
+
+
+def test_vommit_config_beats_a_stale_psr_pin(tmp_path):
+    """Migrating by hand should not also require removing the opt-out."""
+    pyproject = write(tmp_path, VOMMIT + '\n[tool.edwh.release]\nbackend = "psr"\n')
+
+    assert detect_backend(pyproject) == "vommit"
+
+
+def test_pin_to_vommit_without_config_asks_for_setup(tmp_path):
+    """Pinned to vommit but never configured: offer setup, don't fall back to psr."""
+    pyproject = write(tmp_path, PSR)
+    pin_backend("vommit", pyproject)
+
+    assert detect_backend(pyproject) == "none"
+
+
+def test_pin_preserves_comments_and_is_idempotent(tmp_path):
+    pyproject = write(tmp_path, '# keep me\n[project]\nname = "demo" # and me\n')
+
+    pin_backend("psr", pyproject)
+    once = pyproject.read_text()
+    pin_backend("psr", pyproject)
+
+    assert "# keep me" in once
+    assert "# and me" in once
+    assert pyproject.read_text() == once
+
+
+def test_pin_alongside_existing_tool_edwh_table(tmp_path):
+    """[tool.edwh.lint] is the established neighbour; don't clobber it."""
+    pyproject = write(tmp_path, '[project]\nname = "demo"\n\n[tool.edwh.lint]\nty = false\n')
+    pin_backend("psr", pyproject)
+
+    text = pyproject.read_text()
+    assert "ty = false" in text
+    assert pinned_backend(pyproject) == "psr"
+
+
+@pytest.mark.parametrize(
+    "table,uploaded",
+    [
+        ("", True),  # no psr config: nothing was disabled
+        ("[tool.semantic_release]\nbranch = 'main'\n", True),  # v7 defaulted to true
+        ("[tool.semantic_release]\nupload_to_repository = false\n", False),
+        ("[tool.semantic_release]\nupload_to_pypi = false\n", False),
+    ],
+)
+def test_psr_uploaded(tmp_path, table, uploaded):
+    """Read before migrating: vommit strips the table it is derived from."""
+    assert psr_uploaded(write(tmp_path, f'[project]\nname = "demo"\n\n{table}')) is uploaded
+
+
+def test_enable_publishing_restores_the_step_migration_removed(tmp_path):
+    """psr wasn't uploading because plugin.release was; vommit owns that now."""
+    pyproject = write(tmp_path, VOMMIT + "\n[tool.vommit.pypi]\nenabled = false\n")
+    assert vommit_publishes(pyproject) is False
+
+    enable_publishing(pyproject)
+
+    assert vommit_publishes(pyproject) is True
+
+
+def test_publishing_defaults_to_on_without_a_pypi_section(tmp_path):
+    assert vommit_publishes(write(tmp_path, VOMMIT)) is True
+
+
+def test_vommit_tasks_accept_the_arguments_we_pass():
+    """
+    `vommit.tasks` is excluded from vommit's coverage, so it is the surface most
+    likely to be reshaped. Fail here rather than at someone's release.
+    """
+    vommit_tasks = pytest.importorskip("vommit.tasks")
+
+    expected = {
+        "setup": {"project_dir"},
+        "migrate": {"project_dir"},
+        "bump": {"major", "minor", "patch", "prerelease", "noop"},
+        "release": {"major", "minor", "patch", "prerelease", "noop", "yes"},
+    }
+
+    for name, arguments in expected.items():
+        task = getattr(vommit_tasks, name)
+        parameters = set(inspect.signature(task.body).parameters)
+        assert arguments <= parameters, f"vommit.tasks.{name} lost {arguments - parameters}"

--- a/tests/test_release_routing.py
+++ b/tests/test_release_routing.py
@@ -28,7 +28,7 @@ version = "1.0.0"
 
 @pytest.fixture
 def project(tmp_path):
-    """Run inside a throwaway project, with every prompt answered for us."""
+    """Build a throwaway project to run a task inside."""
 
     def make(content: str):
         (tmp_path / "pyproject.toml").write_text(content)
@@ -47,7 +47,12 @@ def no_vommit(monkeypatch):
 def refuses_install(monkeypatch):
     """Decline the install offer, and record that it was made."""
     offered = []
-    monkeypatch.setattr(plugin, "confirm", lambda prompt, **kw: offered.append(prompt) and False)
+
+    def decline(prompt, **_kwargs):
+        offered.append(prompt)
+        return False
+
+    monkeypatch.setattr(plugin, "confirm", decline)
     return offered
 
 
@@ -63,7 +68,8 @@ def no_psr(monkeypatch):
     monkeypatch.setattr(plugin, "_semantic_release_publish", forbidden)
 
 
-def test_configured_for_vommit_but_not_installed_offers_the_install(project, no_vommit, refuses_install):
+@pytest.mark.usefixtures("no_vommit")
+def test_configured_for_vommit_but_not_installed_offers_the_install(project, refuses_install):
     """
     vommit's config outlives its install -- a migrated project cloned onto a
     second machine has [tool.vommit] and no vommit. That has to reach the
@@ -76,7 +82,8 @@ def test_configured_for_vommit_but_not_installed_offers_the_install(project, no_
     assert "vommit is not installed" in refuses_install[0]
 
 
-def test_declining_that_install_does_not_release(project, no_vommit, refuses_install, no_psr):
+@pytest.mark.usefixtures("no_vommit", "refuses_install", "no_psr")
+def test_declining_that_install_does_not_release(project):
     """Refusing the install must stop, not fall back to the deprecated path."""
     with chdir(project(VOMMIT)):
         plugin.release(invoke.Context(), noop=True, pull=False)
@@ -88,8 +95,8 @@ def test_declining_that_install_does_not_release(project, no_vommit, refuses_ins
 def test_accepting_that_install_proceeds(project, monkeypatch):
     """Once vommit is importable, the backend resolves to it."""
     installed = []
-    monkeypatch.setattr(plugin, "confirm", lambda *a, **kw: True)
-    monkeypatch.setattr(plugin, "pip_install", lambda ctx, *specs, **kw: installed.extend(specs))
+    monkeypatch.setattr(plugin, "confirm", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(plugin, "pip_install", lambda _ctx, *specs, **_kwargs: installed.extend(specs))
     # absent until the install "runs", importable afterwards
     monkeypatch.setattr(plugin, "_vommit", lambda: object() if installed else None)
 
@@ -99,7 +106,8 @@ def test_accepting_that_install_proceeds(project, monkeypatch):
     assert installed and installed[0].startswith("vommit")
 
 
-def test_bump_without_any_backend_does_not_reach_psr(project, monkeypatch, no_psr):
+@pytest.mark.usefixtures("no_psr")
+def test_bump_without_any_backend_does_not_reach_psr(project, monkeypatch):
     """
     `release` already refused this; `bump` used to install psr and run it
     against a project that has no psr config.
@@ -122,7 +130,8 @@ def test_install_specifier_carries_the_declared_bound():
     assert plugin._vommit_spec().endswith(specifier)
 
 
-def test_require_vommit_task_keeps_its_result_to_itself(project, no_vommit, refuses_install):
+@pytest.mark.usefixtures("no_vommit", "refuses_install")
+def test_require_vommit_task_keeps_its_result_to_itself(project):
     """
     ewok writes a task's return value into the shared ctx["result"], which the
     enclosing task then returns as its own. `ensure_vommit` is a plain function

--- a/tests/test_release_routing.py
+++ b/tests/test_release_routing.py
@@ -40,7 +40,7 @@ def project(tmp_path):
 @pytest.fixture
 def no_vommit(monkeypatch):
     """An environment where the optional `vommit` extra is not installed."""
-    monkeypatch.setattr(plugin, "_vommit", lambda: None)
+    monkeypatch.setattr(plugin, "vommit_tasks", lambda: None)
 
 
 @pytest.fixture
@@ -98,7 +98,7 @@ def test_accepting_that_install_proceeds(project, monkeypatch):
     monkeypatch.setattr(plugin, "confirm", lambda *_args, **_kwargs: True)
     monkeypatch.setattr(plugin, "pip_install", lambda _ctx, *specs, **_kwargs: installed.extend(specs))
     # absent until the install "runs", importable afterwards
-    monkeypatch.setattr(plugin, "_vommit", lambda: object() if installed else None)
+    monkeypatch.setattr(plugin, "vommit_tasks", lambda: object() if installed else None)
 
     with chdir(project(VOMMIT)):
         assert plugin._resolve_backend(invoke.Context()) == "vommit"
@@ -122,7 +122,7 @@ def test_install_specifier_carries_the_declared_bound():
     """
     The install prompt must not be able to pull a vommit edwh does not support.
     """
-    specifier = plugin._vommit_specifier()
+    specifier = plugin.vommit_specifier()
 
     assert specifier, "no version bound at all"
     assert "<1" in specifier.replace(" ", "")

--- a/tests/test_release_routing.py
+++ b/tests/test_release_routing.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: 2023-present Remco Boerma <remco.b@educationwarehouse.nl>
+#
+# SPDX-License-Identifier: MIT
+"""
+How plugin.release and plugin.bump choose, and refuse, a release backend.
+"""
+
+from contextlib import chdir
+
+import invoke
+import pytest
+
+from src.edwh.local_tasks import plugin
+
+VOMMIT = """[project]
+name = "demo"
+version = "1.0.0"
+
+[tool.vommit]
+prerelease_token = "beta"
+"""
+
+BARE = """[project]
+name = "demo"
+version = "1.0.0"
+"""
+
+
+@pytest.fixture
+def project(tmp_path):
+    """Run inside a throwaway project, with every prompt answered for us."""
+
+    def make(content: str):
+        (tmp_path / "pyproject.toml").write_text(content)
+        return tmp_path
+
+    return make
+
+
+@pytest.fixture
+def no_vommit(monkeypatch):
+    """An environment where the optional `vommit` extra is not installed."""
+    monkeypatch.setattr(plugin, "_vommit", lambda: None)
+
+
+@pytest.fixture
+def refuses_install(monkeypatch):
+    """Decline the install offer, and record that it was made."""
+    offered = []
+    monkeypatch.setattr(plugin, "confirm", lambda prompt, **kw: offered.append(prompt) and False)
+    return offered
+
+
+@pytest.fixture
+def no_psr(monkeypatch):
+    """Make any attempt to reach python-semantic-release loud instead of silent."""
+
+    def forbidden(*_args, **_kwargs):
+        raise AssertionError("reached the python-semantic-release path")
+
+    monkeypatch.setattr(plugin, "_psr_bump", forbidden)
+    monkeypatch.setattr(plugin, "require_semantic_release", forbidden)
+    monkeypatch.setattr(plugin, "_semantic_release_publish", forbidden)
+
+
+def test_configured_for_vommit_but_not_installed_offers_the_install(project, no_vommit, refuses_install):
+    """
+    vommit's config outlives its install -- a migrated project cloned onto a
+    second machine has [tool.vommit] and no vommit. That has to reach the
+    install offer, not an assertion.
+    """
+    with chdir(project(VOMMIT)):
+        assert plugin._resolve_backend(invoke.Context()) is None
+
+    assert refuses_install, "no install was offered"
+    assert "vommit is not installed" in refuses_install[0]
+
+
+def test_declining_that_install_does_not_release(project, no_vommit, refuses_install, no_psr):
+    """Refusing the install must stop, not fall back to the deprecated path."""
+    with chdir(project(VOMMIT)):
+        plugin.release(invoke.Context(), noop=True, pull=False)
+        # ewok hands back its own empty result rather than None, so this asserts
+        # no version came out -- and `no_psr` raises if psr was reached at all
+        assert not plugin.bump(invoke.Context(), noop=True)
+
+
+def test_accepting_that_install_proceeds(project, monkeypatch):
+    """Once vommit is importable, the backend resolves to it."""
+    installed = []
+    monkeypatch.setattr(plugin, "confirm", lambda *a, **kw: True)
+    monkeypatch.setattr(plugin, "pip_install", lambda ctx, *specs, **kw: installed.extend(specs))
+    # absent until the install "runs", importable afterwards
+    monkeypatch.setattr(plugin, "_vommit", lambda: object() if installed else None)
+
+    with chdir(project(VOMMIT)):
+        assert plugin._resolve_backend(invoke.Context()) == "vommit"
+
+    assert installed and installed[0].startswith("vommit")
+
+
+def test_bump_without_any_backend_does_not_reach_psr(project, monkeypatch, no_psr):
+    """
+    `release` already refused this; `bump` used to install psr and run it
+    against a project that has no psr config.
+    """
+    monkeypatch.setattr(plugin, "_can_ask", lambda: False)
+
+    with chdir(project(BARE)):
+        assert not plugin.bump(invoke.Context(), noop=True)
+
+
+def test_install_specifier_carries_the_declared_bound():
+    """
+    The install prompt must not be able to pull a vommit edwh does not support.
+    """
+    specifier = plugin._vommit_specifier()
+
+    assert specifier, "no version bound at all"
+    assert "<1" in specifier.replace(" ", "")
+    assert plugin._vommit_spec().startswith("vommit")
+    assert plugin._vommit_spec().endswith(specifier)
+
+
+def test_require_vommit_task_keeps_its_result_to_itself(project, no_vommit, refuses_install):
+    """
+    ewok writes a task's return value into the shared ctx["result"], which the
+    enclosing task then returns as its own. `ensure_vommit` is a plain function
+    for that reason; the task wrapper must not reintroduce the leak.
+    """
+    ctx = invoke.Context()
+
+    with chdir(project(VOMMIT)):
+        plugin.require_vommit(ctx)
+
+    assert not ctx["result"], f"leaked {ctx['result']!r} into the shared result"

--- a/tests/test_toml_config.py
+++ b/tests/test_toml_config.py
@@ -1,6 +1,6 @@
 from contextlib import chdir
 
-from edwh.tasks import TomlConfig
+from src.edwh.tasks import TomlConfig
 
 
 def test_toml_config_bootstrap_preserves_application_context(tmp_path):


### PR DESCRIPTION
Makes `plugin.release` a router: it inspects the project it runs in and either delegates to [vommit](https://github.com/educationwarehouse/vommit), offers a migration off python-semantic-release, or offers a first-time setup. Switching a plugin over becomes a prompt during a release you were doing anyway.

**Depends on educationwarehouse/vommit#13.** The `[vommit]` extra pins `vommit >= 0.1.1, < 1`, and 0.1.1 is the first release that supports Python 3.12 — this install cannot resolve until that ships. `edwh[dev]` carries the same pin so `edwh lint` can resolve the import, so a dev install is blocked too.

## Routing

`detect_backend` (`src/edwh/release_backend.py`) decides, in this order:

| Project state | Result |
|---|---|
| `[tool.vommit]` present | vommit releases it |
| `[tool.edwh.release] backend = "psr"` | psr, silently — the "never" answer |
| `[tool.semantic_release]` present | psr, and the switch is offered |
| neither | `vommit setup` is offered |

A present `[tool.vommit]` deliberately beats a stale pin, so migrating by hand doesn't also require removing the opt-out.

The switch is a three-way prompt: **migrate now** / **not now** (asks again) / **never** (records `[tool.edwh.release] backend = "psr"` and stops asking). psr keeps working either way, with a deprecation notice naming edwh 2.0. `EDWH_NON_INTERACTIVE=1` suppresses the prompt entirely — `interactive_selected_radio_value` reads the terminal directly and would otherwise hang in CI.

## The publishing trap this fixes

Our v7 configs set `upload_to_repository = false` because `plugin.release` did the uploading itself. vommit translates that faithfully to `pypi.enabled = false`, and it only runs `commands.publish` when that is true — so a migrated plugin would bump, tag and push, and silently never reach PyPI. This is our convention, so it would have hit **every** migration.

vommit cannot know the intent; we can. So the psr upload flags are read *before* the migrator strips the table, and afterwards you are asked whether to turn publishing back on. Declining says out loud what that means rather than leaving it to be discovered next release.

## Why an extra, called in-process

`vommit` is an optional extra, not a dependency, and is imported rather than shelled out to. Being in-process is what makes `plugin.bump` able to return vommit's version string directly — the thing `_semantic_release_publish` has to scrape out of another process' stderr with a regex.

Coupling is four keyword-only call sites into `vommit.tasks`, plus `Config.has_pyproject_config` and `auth.TokenStore` from vommit's tested library layer. `vommit.tasks` is excluded from vommit's own coverage, so a signature smoke test in `tests/` turns a reshape there into a red test instead of a broken release.

Detection stays edwh-native (three TOML lookups via `tomllib`, mirroring `enabled_lint_tools`) because it has to answer "should I offer to install vommit?" *before* vommit exists. That is the only duplication; no vommit constant is copied — the keyring service and username come from `TokenStore`'s defaults.

`require_vommit` installs via `_pip()` into edwh's own environment rather than uvenv, because that is what activates vommit's `edwh` entry point and makes `ew vommit.*` work. It installs `vommit[ssh]` when the ssh-agent keyring is configured, since a plain install cannot reach that token store at all.

## Also in this change

- `plugin.bump` routes the same way.
- `plugin.authenticate` writes both keyring entries (`edwh`/`pypi` and vommit's), so a token works whichever backend a project uses, and warns on a token missing the `pypi-` prefix.
- `publish()` now goes through `ensure_keyring_unlocked()` — a locked keyring previously raised `KeyringLocked` uncaught on headless boxes, exactly when a release needs the token most.
- `--hatch` is refused on the vommit path, pointing at `[tool.vommit.commands]` `build`/`publish` instead.
- `require_semantic_release` is no longer a `pre=` task on `bump`/`release`, so a vommit project no longer installs psr just to release.
- The PyPI token is *copied* into vommit's keyring; edwh's entry is left in place, so a half-finished migration can still release the old way.

## Verification

`pytest tests/ -q` → **18 passed** (`tests/test_release_backend.py` covers every `detect_backend` state, the two ordering cases, pin idempotence and comment preservation, the psr upload flags, and the publishing repair).

Beyond that, every interactive branch was driven with the prompts stubbed, against real synthetic projects carrying our exact psr block:

- *never* → pins, doesn't ask again · *not now* → no pin, asks again
- *migrate now* → `[tool.vommit]` written, `[tool.semantic_release]` stripped, publishing restored; declining that prompt leaves it off
- bare project → setup offer, not migration; *never* → pinned to vommit, still offers setup rather than falling back to psr
- stopping vommit's migrator halfway → falls back to psr for that release instead of delegating to a config that never landed
- `plugin.bump` returns vommit's version and passes only flags vommit has
- `--hatch` on a vommit project refuses and does not release
- `EDWH_NON_INTERACTIVE=1` → no prompt, no hang, one deprecation notice
- `ew --list plugin` and `ew --list vommit` both populate from one environment
- `parse_changelog` reads a vommit-written `CHANGELOG.md`; the `<!-- next-version-placeholder -->` line is ignored, so `plugin.changelog` keeps working after a migration

`ruff check` and `ruff format --check` clean. `ty check src/` is down to the one pre-existing `redis` unresolved-import — this change adds no new diagnostics.

`coding-guidelines.md` documents the routing, the three answers, the publishing note, and the `ew vommit.*` tasks for flags `plugin.release` doesn't expose (`--version`, `--allow-dirty`, `--no-bump`).

## Out of scope

edwh's own `[tool.semantic_release]` block is untouched — that migration is a separate change. Two defects worth catching then: `change_log` (line 163) is not a psr key at all (psr wants `changelog_file`, and fell back to a default that happened to match, so it worked by accident — vommit's migration report flags this unprompted); and `publish`/`test`/`test-cov`/`cov-report`/`cov` sit inside `[tool.hatch.version]`, whose only valid key is `path`, which is why the comment above them documents `hatch run publish` as broken.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F7xaWnWcA79FuBYrPsMb2p)_